### PR TITLE
Fix Release Permissions

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,10 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
-    permissions:
-      id-token: write # For cosign
-      packages: write # For GHCR
-      contents: read # Not required for public repositories, but for clarity
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Reusable template workflow was declaring the wrong permissions, so even though I fixed at the caller level they were being overwritten. Remove those so the caller must specify.