### PR TITLE
Change entrypoint to be methodaws instead of shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,4 @@ USER method
 WORKDIR /opt/method/methodaws/
 
 ENV PATH="/opt/method/methodaws/service/bin:${PATH}"
+ENTRYPOINT [ "methodaws" ]


### PR DESCRIPTION
Changes the docker entrypoint to be `methodaws` instead of the shell