### PR TITLE
Try to parametetize chainguard identity secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       goreleaser_config: goreleaser.yml
       goreleaser_options: "--clean"
+      chainguard_identity_name: CHAINCTL_IDENTITY_DEVELOP
     secrets: inherit
     permissions:
       id-token: write # For cosign

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -11,6 +11,10 @@ on:
         default: ""
         required: false
         type: string
+      chainguard_identity_name:
+        description: "Github Action secret name for Chainguard identity"
+        required: true
+        type: string
 
 env:
   GO_VERSION: "1.22"
@@ -51,7 +55,7 @@ jobs:
       - name: Authenticate with Chainguard
         uses: chainguard-dev/setup-chainctl@v0.2.1
         with:
-          identity: ${{ secrets.CHAINCTL_IDENTITY }}
+          identity: ${{ secrets[inputs.chainguard_identity_name] }}
 
       - name: Checkout code
         uses: actions/checkout@v4.1.6

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       goreleaser_config: goreleaser.yml
       goreleaser_options: "--clean --snapshot"
+      chainguard_identity_name: CHAINCTL_IDENTITY
     secrets: inherit
     permissions:
       id-token: write # For cosign


### PR DESCRIPTION
Chainguard works on the pull requests but not on develop due to the way Chainguard uses Github OIDC subjects to verify. Parameterizing this with two different identities to handle the refs properly.