### PR TITLE
Split build job for PRs and develop to pass in two separate identities

### DIFF
--- a/.github/workflows/test-build-develop.yml
+++ b/.github/workflows/test-build-develop.yml
@@ -1,11 +1,8 @@
 name: 🔨 Build Test
 on:
-  pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "mkdocs.yml"
-      - "LICENSE"
+  push:
+    branches:
+      - develop
 
 jobs:
   build:
@@ -14,7 +11,7 @@ jobs:
     with:
       goreleaser_config: goreleaser.yml
       goreleaser_options: "--clean --snapshot"
-      chainguard_identity_name: CHAINCTL_IDENTITY
+      chainguard_identity_name: CHAINCTL_IDENTITY_DEVELOP
     secrets: inherit
     permissions:
       id-token: write # For cosign


### PR DESCRIPTION
* Since we need a separate Chainguard identity for develop than we do for PRs, need to split the workflow and have one run on develop and another run on PRs.