### PR TITLE
Account ID and Optional Lists

### DIFF
--- a/cmd/loadbalancer.go
+++ b/cmd/loadbalancer.go
@@ -36,11 +36,13 @@ func (a *MethodAws) InitLoadBalancerCommand() {
 			if loadBalancerVersions == "all" || loadBalancerVersions == "v1" {
 				v1Report := loadbalancer.EnumerateV1ELBs(cmd.Context(), *a.AwsConfig)
 				report.V1LoadBalancers = v1Report.V1LoadBalancers
+				report.AccountId = v1Report.AccountId
 				report.Errors = append(report.Errors, v1Report.Errors...)
 			}
 			if loadBalancerVersions == "all" || loadBalancerVersions == "v2" {
 				v2Report := loadbalancer.EnumerateV2LBs(cmd.Context(), *a.AwsConfig)
 				report.V2LoadBalancers = v2Report.V2LoadBalancers
+				report.AccountId = v2Report.AccountId
 				report.Errors = append(report.Errors, v2Report.Errors...)
 			}
 

--- a/fern/definition/loadbalancer.yml
+++ b/fern/definition/loadbalancer.yml
@@ -19,7 +19,7 @@ types:
       arn: optional<string>
       protocol: optional<Protocol>
       port: integer
-      certificates: list<Certificate>
+      certificates: optional<list<Certificate>>
       loadBalancerArn: optional<string>
   TargetGroupIpAddressType:
     enum:

--- a/fern/definition/loadbalancer.yml
+++ b/fern/definition/loadbalancer.yml
@@ -88,6 +88,6 @@ types:
   LoadBalancerReport:
     properties:
       accountId: string
-      v2LoadBalancers: list<LoadBalancerV2>
-      v1LoadBalancers: list<LoadBalancerV1>
-      errors: list<string>
+      v2LoadBalancers: optional<list<LoadBalancerV2>>
+      v1LoadBalancers: optional<list<LoadBalancerV1>>
+      errors: optional<list<string>>

--- a/generated/python/resources/loadbalancer/listener.py
+++ b/generated/python/resources/loadbalancer/listener.py
@@ -13,7 +13,7 @@ class Listener(pydantic_v1.BaseModel):
     arn: typing.Optional[str] = None
     protocol: typing.Optional[Protocol] = None
     port: int
-    certificates: typing.List[Certificate]
+    certificates: typing.Optional[typing.List[Certificate]] = None
     load_balancer_arn: typing.Optional[str] = pydantic_v1.Field(alias="loadBalancerArn", default=None)
 
     def json(self, **kwargs: typing.Any) -> str:

--- a/generated/python/resources/loadbalancer/load_balancer_report.py
+++ b/generated/python/resources/loadbalancer/load_balancer_report.py
@@ -11,9 +11,13 @@ from .load_balancer_v_2 import LoadBalancerV2
 
 class LoadBalancerReport(pydantic_v1.BaseModel):
     account_id: str = pydantic_v1.Field(alias="accountId")
-    v_2_load_balancers: typing.List[LoadBalancerV2] = pydantic_v1.Field(alias="v2LoadBalancers")
-    v_1_load_balancers: typing.List[LoadBalancerV1] = pydantic_v1.Field(alias="v1LoadBalancers")
-    errors: typing.List[str]
+    v_2_load_balancers: typing.Optional[typing.List[LoadBalancerV2]] = pydantic_v1.Field(
+        alias="v2LoadBalancers", default=None
+    )
+    v_1_load_balancers: typing.Optional[typing.List[LoadBalancerV1]] = pydantic_v1.Field(
+        alias="v1LoadBalancers", default=None
+    )
+    errors: typing.Optional[typing.List[str]] = None
 
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {"by_alias": True, "exclude_unset": True, **kwargs}


### PR DESCRIPTION
* Was not setting the Account ID properly
* Fern lists were not being included from Go if they were empty. This made the Python unhappy as they were not None by default. Fixing it by marking them as explicitly optional.