### PR TITLE
Revert Chainguard Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM chainguard/static:latest
 COPY methodaws /
+RUN mkdir -p /mnt/output
 ENTRYPOINT [ "/methodaws" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,30 @@
-FROM chainguard/static:latest
-COPY methodaws /
-RUN mkdir -p /mnt/output
-ENTRYPOINT [ "/methodaws" ]
+FROM alpine:3.20
+
+ARG CLI_NAME="methodaws"
+ARG TARGETARCH
+
+RUN apk update && apk add --no-cache bash jq ca-certificates
+
+# Setup Method Directory Structure
+RUN \
+  mkdir -p /opt/method/${CLI_NAME}/ && \
+  mkdir -p /opt/method/${CLI_NAME}/var/data && \
+  mkdir -p /opt/method/${CLI_NAME}/var/data/tmp && \
+  mkdir -p /opt/method/${CLI_NAME}/var/conf && \
+  mkdir -p /opt/method/${CLI_NAME}/var/log && \
+  mkdir -p /opt/method/${CLI_NAME}/service/bin && \
+  mkdir -p /mnt/output
+
+COPY ${CLI_NAME} /opt/method/${CLI_NAME}/service/bin/${CLI_NAME}
+
+RUN \
+  adduser --disabled-password --gecos '' method && \
+  chown -R method:method /opt/method/${CLI_NAME}/ && \
+  chown -R method:method /mnt/output
+
+USER method
+
+WORKDIR /opt/method/${CLI_NAME}/
+
+ENV PATH="/opt/method/${CLI_NAME}/service/bin:${PATH}"
+ENTRYPOINT [ "methodaws" ]


### PR DESCRIPTION
* Did not have `/mnt/output` created in Chainguard, which we need to run the tools and output for the Agent
* Chainguard static doesn't have sh so can't create paths
* Reverts us back to alpine