### PR TITLE
Add Multi-Region Enumeration Support

### DIFF
--- a/cmd/ec2.go
+++ b/cmd/ec2.go
@@ -19,7 +19,7 @@ func (a *MethodAws) InitEc2Command() {
 		Short: "Enumerate EC2 instances",
 		Long:  `Enumerate EC2 instances`,
 		Run: func(cmd *cobra.Command, args []string) {
-			report, err := ec2.EnumerateEc2(cmd.Context(), *a.AwsConfig)
+			report, err := ec2.EnumerateEc2(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage

--- a/cmd/eks.go
+++ b/cmd/eks.go
@@ -19,7 +19,7 @@ func (a *MethodAws) InitEksCommand() {
 		Short: "Enumerate EKS instances",
 		Long:  `Enumerate EKS instances`,
 		Run: func(cmd *cobra.Command, args []string) {
-			report, err := eks.EnumerateEks(cmd.Context(), *a.AwsConfig)
+			report, err := eks.EnumerateEks(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage

--- a/cmd/loadbalancer.go
+++ b/cmd/loadbalancer.go
@@ -34,13 +34,13 @@ func (a *MethodAws) InitLoadBalancerCommand() {
 			}
 
 			if loadBalancerVersions == "all" || loadBalancerVersions == "v1" {
-				v1Report := loadbalancer.EnumerateV1ELBs(cmd.Context(), *a.AwsConfig)
+				v1Report := loadbalancer.EnumerateV1ELBs(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 				report.V1LoadBalancers = v1Report.V1LoadBalancers
 				report.AccountId = v1Report.AccountId
 				report.Errors = append(report.Errors, v1Report.Errors...)
 			}
 			if loadBalancerVersions == "all" || loadBalancerVersions == "v2" {
-				v2Report := loadbalancer.EnumerateV2LBs(cmd.Context(), *a.AwsConfig)
+				v2Report := loadbalancer.EnumerateV2LBs(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 				report.V2LoadBalancers = v2Report.V2LoadBalancers
 				report.AccountId = v2Report.AccountId
 				report.Errors = append(report.Errors, v2Report.Errors...)

--- a/cmd/rds.go
+++ b/cmd/rds.go
@@ -18,7 +18,7 @@ func (a *MethodAws) InitRdsCommand() {
 		Short: "Enumerate RDS instances",
 		Long:  `Enumerate RDS instances in your AWS account.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			report, err := rds.EnumerateRds(cmd.Context(), *a.AwsConfig)
+			report, err := rds.EnumerateRds(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -18,7 +18,7 @@ func (a *MethodAws) InitS3Command() {
 		Short: "Enumerate all S3 buckets",
 		Long:  `Enumerate all S3 buckets in your AWS account.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			report := s3.EnumerateS3(cmd.Context(), *a.AwsConfig)
+			report := s3.EnumerateS3(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 			a.OutputSignal.Content = report
 		},
 	}
@@ -61,7 +61,7 @@ func (a *MethodAws) InitS3Command() {
 				return
 			}
 
-			report := s3.ExternalEnumerateS3(cmd.Context(), *a.AwsConfig, bucketName)
+			report := s3.ExternalEnumerateS3(cmd.Context(), *a.AwsConfig, bucketName, a.RootFlags.Regions)
 			a.OutputSignal.Content = report
 		},
 	}

--- a/cmd/securitygroup.go
+++ b/cmd/securitygroup.go
@@ -35,7 +35,7 @@ func (a *MethodAws) InitSecurityGroupCommand() {
 				vpcID = nil
 			}
 
-			report, err := ec2.EnumerateSecurityGroups(cmd.Context(), *a.AwsConfig, vpcID)
+			report, err := ec2.EnumerateSecurityGroupsForRegion(cmd.Context(), *a.AwsConfig, vpcID, a.RootFlags.Regions[0])
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -19,7 +19,7 @@ func (a *MethodAws) InitVPCCommand() {
 		Short: "Enumerate all VPCs",
 		Long:  `Enumerate all VPCs in your AWS account.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			report, err := vpc.EnumerateVPC(cmd.Context(), *a.AwsConfig)
+			report, err := vpc.EnumerateVPC(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage

--- a/fern/definition/loadbalancer.yml
+++ b/fern/definition/loadbalancer.yml
@@ -64,6 +64,7 @@ types:
     properties:
       arn: string
       name: string
+      region: string
       createdTime: datetime
       dnsName: string
       ipAddressType: IpAddressType
@@ -77,6 +78,7 @@ types:
   LoadBalancerV1:
     properties:
       name: string
+      region: string
       createdTime: datetime
       dnsName: string
       securityGroupIds: optional<list<string>>

--- a/fern/definition/s3.yml
+++ b/fern/definition/s3.yml
@@ -36,6 +36,7 @@ types:
       name: string
       arn: string
       url: string
+      region: string
       creationDate: datetime
       ownerID: string
       ownerName: string
@@ -47,7 +48,6 @@ types:
   S3Report:
     properties:
       accountId: string
-      region: string
       s3Buckets: optional<list<Bucket>>
       errors: optional<list<string>>
   S3ObjectDetails:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "0.41.0"
+  "version": "0.41.8"
 }

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -301,6 +301,7 @@ func (l LoadBalancerState) Ptr() *LoadBalancerState {
 
 type LoadBalancerV1 struct {
 	Name             string      `json:"name" url:"name"`
+	Region           string      `json:"region" url:"region"`
 	CreatedTime      time.Time   `json:"createdTime" url:"createdTime"`
 	DnsName          string      `json:"dnsName" url:"dnsName"`
 	SecurityGroupIds []string    `json:"securityGroupIds,omitempty" url:"securityGroupIds,omitempty"`
@@ -371,6 +372,7 @@ func (l *LoadBalancerV1) String() string {
 type LoadBalancerV2 struct {
 	Arn              string             `json:"arn" url:"arn"`
 	Name             string             `json:"name" url:"name"`
+	Region           string             `json:"region" url:"region"`
 	CreatedTime      time.Time          `json:"createdTime" url:"createdTime"`
 	DnsName          string             `json:"dnsName" url:"dnsName"`
 	IpAddressType    IpAddressType      `json:"ipAddressType" url:"ipAddressType"`
@@ -618,6 +620,7 @@ type Bucket struct {
 	Name               string                            `json:"name" url:"name"`
 	Arn                string                            `json:"arn" url:"arn"`
 	Url                string                            `json:"url" url:"url"`
+	Region             string                            `json:"region" url:"region"`
 	CreationDate       time.Time                         `json:"creationDate" url:"creationDate"`
 	OwnerId            string                            `json:"ownerID" url:"ownerID"`
 	OwnerName          string                            `json:"ownerName" url:"ownerName"`
@@ -1010,7 +1013,6 @@ func (s *S3PublicAccessBlockConfiguration) String() string {
 
 type S3Report struct {
 	AccountId string    `json:"accountId" url:"accountId"`
-	Region    string    `json:"region" url:"region"`
 	S3Buckets []*Bucket `json:"s3Buckets,omitempty" url:"s3Buckets,omitempty"`
 	Errors    []string  `json:"errors,omitempty" url:"errors,omitempty"`
 

--- a/godel/config/format-plugin.yml
+++ b/godel/config/format-plugin.yml
@@ -1,0 +1,3 @@
+exclude:
+  paths:
+    - generated/**

--- a/internal/common/regions.go
+++ b/internal/common/regions.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+func GetAWSRegions(selectedRegions []string) []string {
+	if len(selectedRegions) > 0 {
+		return selectedRegions
+	}
+
+	resolver := endpoints.DefaultResolver()
+	partitions := resolver.(endpoints.EnumPartitions).Partitions()
+
+	var regions []string
+	for _, p := range partitions {
+		for region := range p.Regions() {
+			regions = append(regions, region)
+		}
+	}
+
+	return regions
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,5 +4,5 @@ package config
 type RootFlags struct {
 	Quiet   bool
 	Verbose bool
-	Region  string
+	Regions []string
 }

--- a/internal/ec2/ec2.go
+++ b/internal/ec2/ec2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 )
 
-// EnumerateEc2 enumerates all of the EC2 instances that the caller has access to. It returns a ResourceReport struct
+// EnumerateEc2ForRegion enumerates all of the EC2 instances that the caller has access to. It returns a ResourceReport struct
 // that contains the EC2 instances and any non-fatal errors that occurred during the execution of the subcommand.
 func EnumerateEc2ForRegion(ctx context.Context, cfg aws.Config, region string) (*ResourceReport, error) {
 	cfg.Region = region

--- a/internal/ec2/report.go
+++ b/internal/ec2/report.go
@@ -8,6 +8,7 @@ import (
 type InstanceWithIAMRole struct {
 	Instance types.Instance `json:"instance" yaml:"instance"`
 	IAMRoles []string       `json:"iam_roles,omitempty" yaml:"iam_roles,omitempty"`
+	Region   string         `json:"region,omitempty" yaml:"region,omitempty"`
 }
 
 // Instances represents all of the EC2 instances that were returned during the reporting process

--- a/internal/ec2/securitygroups.go
+++ b/internal/ec2/securitygroups.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-// EnumerateSecurityGroups lists all of the security groups available to the caller alongside any non-fatal errors that
+// EnumerateSecurityGroupsForRegion lists all of the security groups available to the caller alongside any non-fatal errors that
 // occurred during the execution of the `methodaws securitygroup enumerate` subcommand.
 // If vpcID is not nil, it will only return security groups associated with that VPC.
 func EnumerateSecurityGroupsForRegion(ctx context.Context, cfg aws.Config, vpcID *string, region string) (SecurityGroupReport, error) {

--- a/internal/ec2/securitygroups.go
+++ b/internal/ec2/securitygroups.go
@@ -12,7 +12,9 @@ import (
 // EnumerateSecurityGroups lists all of the security groups available to the caller alongside any non-fatal errors that
 // occurred during the execution of the `methodaws securitygroup enumerate` subcommand.
 // If vpcID is not nil, it will only return security groups associated with that VPC.
-func EnumerateSecurityGroups(ctx context.Context, cfg aws.Config, vpcID *string) (SecurityGroupReport, error) {
+func EnumerateSecurityGroupsForRegion(ctx context.Context, cfg aws.Config, vpcID *string, region string) (SecurityGroupReport, error) {
+	cfg.Region = region
+
 	svc := ec2.NewFromConfig(cfg)
 	errors := []string{}
 	var securityGroups []types.SecurityGroup

--- a/internal/eks/eks.go
+++ b/internal/eks/eks.go
@@ -45,7 +45,7 @@ type AWSResourceReport struct {
 	Errors    []string     `json:"errors"`
 }
 
-// EnumerateEks enumerates all EKS clusters in a specified regionand their associated node groups and EC2 instances. Non-fatal errors
+// EnumerateEksForRegion enumerates all EKS clusters in a specified regionand their associated node groups and EC2 instances. Non-fatal errors
 // will be captured and returned in the report. However, if a fatal error occurs (e.g., during the initial listing of
 // clusters), the function will return early with the error.
 func EnumerateEksForRegion(ctx context.Context, cfg aws.Config, region string) (*AWSResourceReport, error) {

--- a/internal/loadbalancer/elb.go
+++ b/internal/loadbalancer/elb.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 )
 
-// Returns v1 Load Balancers for the specified Region
+// EnumerateV1ELBsForRegion returns v1 Load Balancers for the specified Region
 func EnumerateV1ELBsForRegion(ctx context.Context, cfg aws.Config, region string) methodaws.LoadBalancerReport {
 	cfg.Region = region
 
@@ -74,7 +74,7 @@ func EnumerateV1ELBsForRegion(ctx context.Context, cfg aws.Config, region string
 	}
 }
 
-// Returns v1 Load Balancers for the specified Regions and will consolidate all regional reports into a single report
+// EnumerateV1ELBs returns v1 Load Balancers for the specified Regions and will consolidate all regional reports into a single report
 func EnumerateV1ELBs(ctx context.Context, cfg aws.Config, regions []string) methodaws.LoadBalancerReport {
 	accountID, err := sts.GetAccountID(ctx, cfg)
 	if err != nil {

--- a/internal/rds/rds.go
+++ b/internal/rds/rds.go
@@ -39,7 +39,7 @@ func listRDSInstances(ctx context.Context, rdsClient *rds.Client) ([]types.DBIns
 	return instances, nil
 }
 
-// EnumerateRds retrieves all RDS instances available to the caller and returns an AWSResourceReport struct
+// EnumerateRdsForRegion retrieves all RDS instances available to the caller and returns an AWSResourceReport struct
 func EnumerateRdsForRegion(ctx context.Context, cfg aws.Config, region string) (*AWSResourceReport, error) {
 	cfg.Region = region
 

--- a/internal/s3/external.go
+++ b/internal/s3/external.go
@@ -141,7 +141,7 @@ func checkACL(ctx context.Context, client *s3.Client, bucketName string) ([]*met
 	return acls, nil
 }
 
-// externalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region.
+// ExternalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region.
 // If the bucket does not exist, it will return an unmodified report (with potential new errors).
 func ExternalEnumerateS3Region(ctx context.Context, report methodaws.ExternalS3Report, bucketName string, region string) methodaws.ExternalS3Report {
 	// Check if bucket exists before proceeding

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -90,7 +90,7 @@ func bucketPolicy(ctx context.Context, s3Client *s3.Client, bucket *methodaws.Bu
 	return bucket, nil
 }
 
-// EnumerateS3 retrieves all S3 buckets available to the caller and returns an EnumerateResourceReport struct. Non-fatal
+// EnumerateS3ForRegion retrieves all S3 buckets available to the caller and returns an EnumerateResourceReport struct. Non-fatal
 // errors that occur during the execution of the `methodaws s3 enumerate` subcommand are included in the report, but
 // the function will not return an error unless there is an issue retrieving the account ID.
 func EnumerateS3ForRegion(ctx context.Context, cfg aws.Config, region string) methodaws.S3Report {

--- a/internal/vpc/report.go
+++ b/internal/vpc/report.go
@@ -7,7 +7,8 @@ import (
 
 // The Instance struct contains the VPC data that was enumerated, wrapping the AWS values
 type Instance struct {
-	VPC types.Vpc `json:"vpc" yaml:"vpc"`
+	VPC    types.Vpc `json:"vpc" yaml:"vpc"`
+	Region string    `json:"region" yaml:"region"`
 }
 
 // The Report struct contains the account ID that the VPCs were discovered in, the resources themselves,

--- a/internal/vpc/vpc.go
+++ b/internal/vpc/vpc.go
@@ -8,9 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
-// EnumerateVPC lists the VPCs available to the caller for a particular regionand returns a Report struct. The Report
+// EnumerateVPCForRegion lists the VPCs available to the caller for a particular regionand returns a Report struct. The Report
 // contains all non-fatal errors that occurred during the execution of the `methodaws vpc enumerate` subcommand.
-// EnumerateVPC will return an error if the account ID cannot be retrieved.
+// EnumerateVPCForRegion will return an error if the account ID cannot be retrieved.
 func EnumerateVPCForRegion(ctx context.Context, cfg aws.Config, region string) (report Report, err error) {
 	cfg.Region = region
 

--- a/main.go
+++ b/main.go
@@ -7,12 +7,12 @@ import (
 	"github.com/Method-Security/methodaws/cmd"
 )
 
-var version = "none"
+var Version = "none"
 
 func main() {
 	flag.Parse()
 
-	methodaws := cmd.NewMethodAws(version)
+	methodaws := cmd.NewMethodAws(Version)
 	methodaws.InitRootCommand()
 	methodaws.InitEc2Command()
 	methodaws.InitS3Command()


### PR DESCRIPTION
* Removes the requirement that every command have a `--region` passed to it
    * If no region is set, it will try all regions
    * You can also now specify `--region` multiple times to try select regions
* Adds `region` data to select signals where it made sense
    * Admittedly did not get this everywhere (missing SGs and RDS) but will need to wait til we Fern-ify everything 
* Closes MET-2060