### PR TITLE
Set a default region

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func (a *MethodAws) InitRootCommand() {
 				return err
 			}
 			a.AwsConfig = &awsconfig
+			a.AwsConfig.Region = a.RootFlags.Regions[0]
 
 			return nil
 		},


### PR DESCRIPTION
* Needed to add a default region to the config
* This worked locally because I had a `.aws/config` file that specified a region. My bad, I should have tested in the container.