### PR TITLE
WAF: Add default ACL

### DIFF
--- a/fern/definition/waf.yml
+++ b/fern/definition/waf.yml
@@ -62,6 +62,7 @@ types:
       arn: string
       name: string
       description: optional<string>
+      defaultAction: ActionType
       rules: optional<list<RuleInfo>>
       resources: optional<list<ResourceInfo>>
   RegionWafInfo:

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -1257,11 +1257,12 @@ func (s StatementType) Ptr() *StatementType {
 }
 
 type Waf struct {
-	Arn         string          `json:"arn" url:"arn"`
-	Name        string          `json:"name" url:"name"`
-	Description *string         `json:"description,omitempty" url:"description,omitempty"`
-	Rules       []*RuleInfo     `json:"rules,omitempty" url:"rules,omitempty"`
-	Resources   []*ResourceInfo `json:"resources,omitempty" url:"resources,omitempty"`
+	Arn           string          `json:"arn" url:"arn"`
+	Name          string          `json:"name" url:"name"`
+	Description   *string         `json:"description,omitempty" url:"description,omitempty"`
+	DefaultAction ActionType      `json:"defaultAction" url:"defaultAction"`
+	Rules         []*RuleInfo     `json:"rules,omitempty" url:"rules,omitempty"`
+	Resources     []*ResourceInfo `json:"resources,omitempty" url:"resources,omitempty"`
 
 	extraProperties map[string]interface{}
 }

--- a/internal/waf/waf.go
+++ b/internal/waf/waf.go
@@ -36,7 +36,7 @@ func EnumerateWAF(ctx context.Context, cfg aws.Config, regions []string) (*metho
 
 		var wafs []*methodaws.Waf
 		for _, webACL := range webACLsOutput.WebACLs {
-			rules, errs := getRules(ctx, wafClient, types.ScopeRegional, webACL.Id, webACL.Name)
+			rules, defaultAction, errs := getRules(ctx, wafClient, types.ScopeRegional, webACL.Id, webACL.Name)
 			if len(errs) != 0 {
 				allErrors = append(allErrors, errs...)
 				continue
@@ -50,11 +50,12 @@ func EnumerateWAF(ctx context.Context, cfg aws.Config, regions []string) (*metho
 
 			description := aws.ToString(webACL.Description)
 			waf := methodaws.Waf{
-				Arn:         aws.ToString(webACL.ARN),
-				Name:        aws.ToString(webACL.Name),
-				Description: &description,
-				Rules:       rules,
-				Resources:   resources,
+				Arn:           aws.ToString(webACL.ARN),
+				Name:          aws.ToString(webACL.Name),
+				Description:   &description,
+				DefaultAction: *defaultAction,
+				Rules:         rules,
+				Resources:     resources,
 			}
 			wafs = append(wafs, &waf)
 		}
@@ -74,12 +75,19 @@ func EnumerateWAF(ctx context.Context, cfg aws.Config, regions []string) (*metho
 	return &report, nil
 }
 
-func getRules(ctx context.Context, wafClient *wafv2.Client, scope types.Scope, webACLId, webACLName *string) ([]*methodaws.RuleInfo, []string) {
+func getRules(ctx context.Context, wafClient *wafv2.Client, scope types.Scope, webACLId, webACLName *string) ([]*methodaws.RuleInfo, *methodaws.ActionType, []string) {
 	getWebACLInput := &wafv2.GetWebACLInput{Id: webACLId, Name: webACLName, Scope: scope}
 	webACLOutput, err := wafClient.GetWebACL(ctx, getWebACLInput)
 	if err != nil {
-		return nil, []string{err.Error()}
+		return nil, nil, []string{err.Error()}
 	}
+
+	// Default Action
+	defaultAction := webACLOutput.WebACL.DefaultAction
+	if defaultAction == nil {
+		return nil, nil, []string{"no default action specified"}
+	}
+	defaultActionType := getDefaultActionType(defaultAction)
 
 	var rules []*methodaws.RuleInfo
 	var errors []string
@@ -126,7 +134,8 @@ func getRules(ctx context.Context, wafClient *wafv2.Client, scope types.Scope, w
 		}
 		rules = append(rules, &ruleInfo)
 	}
-	return rules, errors
+
+	return rules, &defaultActionType, errors
 }
 
 func getResources(ctx context.Context, wafClient *wafv2.Client, webACLArn *string) ([]*methodaws.ResourceInfo, error) {
@@ -159,6 +168,17 @@ func getActionType(action *types.RuleAction) methodaws.ActionType {
 		return methodaws.ActionTypeChallenge
 	case action.Count != nil:
 		return methodaws.ActionTypeCount
+	default:
+		return methodaws.ActionTypeOther
+	}
+}
+
+func getDefaultActionType(action *types.DefaultAction) methodaws.ActionType {
+	switch {
+	case action.Allow != nil:
+		return methodaws.ActionTypeAllow
+	case action.Block != nil:
+		return methodaws.ActionTypeBlock
 	default:
 		return methodaws.ActionTypeOther
 	}


### PR DESCRIPTION
- Added a Default Action field to the signal that represents the action the WAF takes when the request doesn't match any of the rules

**Example**

```
{
    "accountId": "XXXX",
    "scope": "REGIONAL",
    "regions": [
        {
            "region": "us-east-1",
            "wafs": [
                {
                    "arn": "arn:aws:XXXX",
                    "name": "waf-XXXX",
                    "description": "WAF that protects the ALB with admin rule set",
                    "defaultAction": "ALLOW",
                    "rules": [
                                ...
                    ],
                    "resources": [
                        {
                            "arn": "arn:aws:XXXX",
                            "type": "XXXX"
                        }
                    ]
                }
            ]
        }
    ]
}
```