### PR TITLE
Fix CLI to enumerate all regions when 'all' is passed

### DIFF
--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/Method-Security/methodaws/internal/s3"
+	"github.com/Method-Security/methodaws/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +72,13 @@ func (a *MethodAws) InitS3Command() {
 				a.OutputSignal.Status = 1
 				return
 			}
-			report := s3.ExternalEnumerateS3(cmd.Context(), bucketName, a.RootFlags.Regions)
+
+			regions := a.RootFlags.Regions
+			if len(a.RootFlags.Regions) == 0 || a.RootFlags.Regions[0] == "all" {
+				regions = utils.GetGeneralRegions()
+			}
+
+			report := s3.ExternalEnumerateS3(cmd.Context(), bucketName, regions)
 			a.OutputSignal.Content = report
 		},
 	}

--- a/utils/regions.go
+++ b/utils/regions.go
@@ -1,0 +1,38 @@
+package utils
+
+// GetGeneralRegions returns a list of known AWS regions.
+func GetGeneralRegions() []string {
+	return []string{
+		"us-east-1",    // N. Virginia (default legacy region, can omit region in URLs)
+		"us-east-2",    // Ohio
+		"us-west-1",    // N. California
+		"us-west-2",    // Oregon
+		"ca-central-1", // Canada (Central)
+
+		"eu-west-1",    // Ireland
+		"eu-west-2",    // London
+		"eu-west-3",    // Paris
+		"eu-central-1", // Frankfurt
+		"eu-north-1",   // Stockholm
+		"eu-south-1",   // Milan
+		"eu-south-2",   // Spain
+		"eu-central-2", // Zurich
+
+		"ap-northeast-1", // Tokyo
+		"ap-northeast-2", // Seoul
+		"ap-northeast-3", // Osaka
+		"ap-southeast-1", // Singapore
+		"ap-southeast-2", // Sydney
+		"ap-southeast-3", // Jakarta
+		"ap-southeast-4", // Melbourne
+		"ap-south-1",     // Mumbai
+		"ap-south-2",     // Hyderabad
+		"ap-east-1",      // Hong Kong
+
+		"me-south-1",   // Bahrain
+		"me-central-1", // UAE
+
+		"sa-east-1",  // São Paulo
+		"af-south-1", // Cape Town
+	}
+}


### PR DESCRIPTION
## Overview

The CLI was trying 'all' instead of enumerating _all_ regions. The fix enumerates all regions if the _all_ is set in the region flag

## Example Error

```
"Error checking bucket in region all: error checking bucket: operation error S3: HeadBucket, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Head \"https://s3.all.amazonaws.com/https%3A%2F%example.example.com%3A443\": dial tcp: lookup s3.all.amazonaws.com: no such host",
```