### PR TITLE
Fix S3 External Enumerate to hunt off URLs

### DIFF
--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -65,7 +65,7 @@ func (a *MethodAws) InitS3Command() {
 			return a.setupCommonConfig(cmd, outputFormat, outputFile, false)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			bucketName, err := cmd.Flags().GetString("name")
+			bucketURL, err := cmd.Flags().GetString("url")
 			if err != nil {
 				errorMessage := err.Error()
 				a.OutputSignal.ErrorMessage = &errorMessage
@@ -74,16 +74,17 @@ func (a *MethodAws) InitS3Command() {
 			}
 
 			regions := a.RootFlags.Regions
-			if len(a.RootFlags.Regions) == 0 || a.RootFlags.Regions[0] == "all" {
+			if len(regions) == 0 || regions[0] == "all" {
 				regions = utils.GetGeneralRegions()
 			}
 
-			report := s3.ExternalEnumerateS3(cmd.Context(), bucketName, regions)
+			report := s3.ExternalEnumerateS3(cmd.Context(), bucketURL, regions)
 			a.OutputSignal.Content = report
 		},
 	}
 
-	externalEnumerateCmd.Flags().String("name", "", "Name of the S3 bucket")
+	externalEnumerateCmd.Flags().String("url", "", "URL of the S3 bucket")
+	_ = externalEnumerateCmd.MarkFlagRequired("url")
 
 	s3Cmd.AddCommand(enumerateCmd)
 	s3Cmd.AddCommand(lsCmd)

--- a/fern/definition/s3.yml
+++ b/fern/definition/s3.yml
@@ -67,6 +67,8 @@ types:
       allowAnonymousRead: boolean
       policy: optional<string>
       acls: optional<list<S3BucketACL>>
+      ownerID: optional<string>
+      ownerName: optional<string>
   ExternalS3Report:
     properties:
       externalBuckets: optional<list<ExternalBucket>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -1523,6 +1523,8 @@ type ExternalBucket struct {
 	AllowAnonymousRead    bool               `json:"allowAnonymousRead" url:"allowAnonymousRead"`
 	Policy                *string            `json:"policy,omitempty" url:"policy,omitempty"`
 	Acls                  []*S3BucketAcl     `json:"acls,omitempty" url:"acls,omitempty"`
+	OwnerId               *string            `json:"ownerID,omitempty" url:"ownerID,omitempty"`
+	OwnerName             *string            `json:"ownerName,omitempty" url:"ownerName,omitempty"`
 
 	extraProperties map[string]interface{}
 }

--- a/internal/s3/external.go
+++ b/internal/s3/external.go
@@ -68,18 +68,17 @@ func bucketExists(ctx context.Context, region string, bucketName string) (bool, 
 	// Create an S3 client
 	client := s3.NewFromConfig(cfg)
 
-	// Try ListObjectsV2 with max keys 0 to check existence
-	_, err = client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket:  aws.String(bucketName),
-		MaxKeys: aws.Int32(0),
+	// Try HeadBucket to check existence
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
 	})
 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
-			case "NoSuchBucket", "NotFound":
+			case "NotFound", "NoSuchBucket":
 				return false, nil
-			case "AccessDenied", "Forbidden":
+			case "Forbidden", "AccessDenied":
 				return true, nil // Bucket exists but we don't have access
 			default:
 				return false, fmt.Errorf("error checking bucket: %v", err)
@@ -97,8 +96,9 @@ func listBucketContents(ctx context.Context, client *s3.Client, bucketName strin
 	directoryContents := []*methodaws.S3ObjectDetails{}
 
 	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
-		Bucket:  aws.String(bucketName),
-		MaxKeys: &maxKeys,
+		Bucket:     aws.String(bucketName),
+		MaxKeys:    &maxKeys,
+		FetchOwner: aws.Bool(true),
 	})
 
 	// Get first page only to avoid overwhelming the API
@@ -112,19 +112,19 @@ func listBucketContents(ctx context.Context, client *s3.Client, bucketName strin
 		if object.Size != nil {
 			size = int(*object.Size)
 		}
-		var ownerID string
-		var ownerName string
-		if object.Owner != nil {
-			ownerID = *object.Owner.ID
-			ownerName = *object.Owner.DisplayName
-		}
-		directoryContents = append(directoryContents, &methodaws.S3ObjectDetails{
+
+		details := &methodaws.S3ObjectDetails{
 			Key:          *object.Key,
 			LastModified: object.LastModified,
 			Size:         &size,
-			OwnerId:      &ownerID,
-			OwnerName:    &ownerName,
-		})
+		}
+
+		if object.Owner != nil {
+			details.OwnerId = object.Owner.ID
+			details.OwnerName = object.Owner.DisplayName
+		}
+
+		directoryContents = append(directoryContents, details)
 	}
 
 	return directoryContents, nil
@@ -134,8 +134,9 @@ func listBucketContents(ctx context.Context, client *s3.Client, bucketName strin
 func checkListingAllowed(ctx context.Context, client *s3.Client, bucketName string) bool {
 	maxKeys := int32(1)
 	_, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket:  aws.String(bucketName),
-		MaxKeys: &maxKeys,
+		Bucket:     aws.String(bucketName),
+		MaxKeys:    &maxKeys,
+		FetchOwner: aws.Bool(true),
 	})
 	return err == nil
 }
@@ -163,27 +164,34 @@ func checkPolicy(ctx context.Context, client *s3.Client, bucketName string) (str
 	return "", fmt.Errorf("error getting bucket policy: %v", err)
 }
 
-// checkAcl checks the bucket ACL
-func checkACL(ctx context.Context, client *s3.Client, bucketName string) ([]*methodaws.S3BucketAcl, error) {
-	aclOutput, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+// checkACL checks the bucket ACL
+func checkACL(ctx context.Context, client *s3.Client, bucketName string) ([]*methodaws.S3BucketAcl, *string, *string, error) {
+	acls := []*methodaws.S3BucketAcl{}
+
+	output, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
 		Bucket: aws.String(bucketName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting bucket ACL: %v", err)
+		return nil, nil, nil, err
 	}
 
-	acls := []*methodaws.S3BucketAcl{}
-	for _, grant := range aclOutput.Grants {
+	// Extract owner information
+	var ownerID, ownerName *string
+	if output.Owner != nil {
+		ownerID = output.Owner.ID
+		ownerName = output.Owner.DisplayName
+	}
+
+	for _, grant := range output.Grants {
 		if grant.Grantee.URI != nil {
-			acl := &methodaws.S3BucketAcl{
+			acls = append(acls, &methodaws.S3BucketAcl{
 				GranteeUri: *grant.Grantee.URI,
 				Permission: string(grant.Permission),
-			}
-			acls = append(acls, acl)
+			})
 		}
 	}
 
-	return acls, nil
+	return acls, ownerID, ownerName, nil
 }
 
 // ExternalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region
@@ -229,10 +237,12 @@ func ExternalEnumerateS3Region(ctx context.Context, report methodaws.ExternalS3R
 		report.Errors = append(report.Errors, fmt.Sprintf("Error getting bucket policy: %v", err))
 	}
 
-	// Check bucket ACL
-	acls, err := checkACL(ctx, client, bucketName)
+	// Check bucket ACL and get owner information
+	acls, ownerID, ownerName, err := checkACL(ctx, client, bucketName)
 	if err == nil {
 		externalBucket.Acls = acls
+		externalBucket.OwnerId = ownerID
+		externalBucket.OwnerName = ownerName
 	} else {
 		report.Errors = append(report.Errors, fmt.Sprintf("Error getting bucket ACL: %v", err))
 	}

--- a/internal/s3/external.go
+++ b/internal/s3/external.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	methodaws "github.com/Method-Security/methodaws/generated/go"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,6 +12,49 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// parseBucketURL extracts bucket name and potentially region from S3 URL
+// Handles formats like:
+// - https://bucket-name.s3.region.amazonaws.com
+// - https://s3.region.amazonaws.com/bucket-name
+// - bucket-name.s3.region.amazonaws.com
+func parseBucketURL(bucketURL string) (bucketName string, region string) {
+	// Remove protocol if present
+	bucketURL = strings.TrimPrefix(bucketURL, "https://")
+	bucketURL = strings.TrimPrefix(bucketURL, "http://")
+
+	// Handle non-standard URLs (e.g., https://image-api.fox.com)
+	if !strings.Contains(bucketURL, "amazonaws.com") {
+		return bucketURL, ""
+	}
+
+	// Parse standard S3 URLs
+	if strings.Contains(bucketURL, "/") {
+		// Format: s3.region.amazonaws.com/bucket-name
+		parts := strings.SplitN(bucketURL, "/", 2)
+		bucketName = parts[1]
+		hostParts := strings.Split(parts[0], ".")
+		if len(hostParts) >= 4 && hostParts[0] == "s3" {
+			region = hostParts[1]
+		}
+	} else {
+		// Format: bucket-name.s3.region.amazonaws.com
+		parts := strings.Split(bucketURL, ".")
+		if len(parts) >= 5 {
+			bucketName = parts[0]
+			if parts[1] == "s3" {
+				region = parts[2]
+			}
+		}
+	}
+
+	// Clean up bucket name
+	bucketName = strings.Split(bucketName, "?")[0]
+	bucketName = strings.TrimRight(bucketName, "/")
+
+	return bucketName, region
+}
+
+// bucketExists checks if a bucket exists and is accessible
 func bucketExists(ctx context.Context, region string, bucketName string) (bool, error) {
 	// Create a custom AWS config with anonymous credentials
 	cfg, err := config.LoadDefaultConfig(ctx,
@@ -24,18 +68,19 @@ func bucketExists(ctx context.Context, region string, bucketName string) (bool, 
 	// Create an S3 client
 	client := s3.NewFromConfig(cfg)
 
-	// Call HeadBucket operation
-	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucketName),
+	// Try ListObjectsV2 with max keys 0 to check existence
+	_, err = client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucketName),
+		MaxKeys: aws.Int32(0),
 	})
 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
-			case "NotFound":
+			case "NoSuchBucket", "NotFound":
 				return false, nil
-			case "Forbidden":
-				return true, nil
+			case "AccessDenied", "Forbidden":
+				return true, nil // Bucket exists but we don't have access
 			default:
 				return false, fmt.Errorf("error checking bucket: %v", err)
 			}
@@ -43,43 +88,43 @@ func bucketExists(ctx context.Context, region string, bucketName string) (bool, 
 		return false, fmt.Errorf("error checking bucket: %v", err)
 	}
 
-	// If there's no error, the bucket exists
 	return true, nil
 }
 
-// listBucketContents lists all objects in a bucket
+// listBucketContents attempts to list objects in the bucket
 func listBucketContents(ctx context.Context, client *s3.Client, bucketName string) ([]*methodaws.S3ObjectDetails, error) {
+	maxKeys := int32(100) // Limit the number of objects to list
 	directoryContents := []*methodaws.S3ObjectDetails{}
+
 	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
-		Bucket: aws.String(bucketName),
+		Bucket:  aws.String(bucketName),
+		MaxKeys: &maxKeys,
 	})
 
-	// Capture all objects in the bucket
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("error listing bucket contents: %v", err)
-		}
+	// Get first page only to avoid overwhelming the API
+	page, err := paginator.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing bucket contents: %v", err)
+	}
 
-		for _, object := range page.Contents {
-			var size int
-			if object.Size != nil {
-				size = int(*object.Size)
-			}
-			var ownerID string
-			var ownerName string
-			if object.Owner != nil {
-				ownerID = *object.Owner.ID
-				ownerName = *object.Owner.DisplayName
-			}
-			directoryContents = append(directoryContents, &methodaws.S3ObjectDetails{
-				Key:          *object.Key,
-				LastModified: object.LastModified,
-				Size:         &size,
-				OwnerId:      &ownerID,
-				OwnerName:    &ownerName,
-			})
+	for _, object := range page.Contents {
+		var size int
+		if object.Size != nil {
+			size = int(*object.Size)
 		}
+		var ownerID string
+		var ownerName string
+		if object.Owner != nil {
+			ownerID = *object.Owner.ID
+			ownerName = *object.Owner.DisplayName
+		}
+		directoryContents = append(directoryContents, &methodaws.S3ObjectDetails{
+			Key:          *object.Key,
+			LastModified: object.LastModified,
+			Size:         &size,
+			OwnerId:      &ownerID,
+			OwnerName:    &ownerName,
+		})
 	}
 
 	return directoryContents, nil
@@ -141,21 +186,8 @@ func checkACL(ctx context.Context, client *s3.Client, bucketName string) ([]*met
 	return acls, nil
 }
 
-// ExternalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region.
-// If the bucket does not exist, it will return an unmodified report (with potential new errors).
+// ExternalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region
 func ExternalEnumerateS3Region(ctx context.Context, report methodaws.ExternalS3Report, bucketName string, region string) methodaws.ExternalS3Report {
-	// Check if bucket exists before proceeding
-	exists, err := bucketExists(ctx, region, bucketName)
-	if err != nil {
-		return report
-	}
-	if !exists {
-		return report
-	}
-
-	// Enumerate the bucket
-	externalBucket := methodaws.ExternalBucket{}
-
 	// Create a custom AWS config with anonymous credentials
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
@@ -169,24 +201,25 @@ func ExternalEnumerateS3Region(ctx context.Context, report methodaws.ExternalS3R
 	// Create an S3 client
 	client := s3.NewFromConfig(cfg)
 
-	// Populate basic information
-	externalBucket.Name = bucketName
-	externalBucket.Url = fmt.Sprintf("https://%s.s3.%s.amazonaws.com", bucketName, cfg.Region)
-	externalBucket.Region = region
-
-	// List bucket contents
-	directoryContents, err := listBucketContents(ctx, client, bucketName)
-	if err != nil {
-		report.Errors = append(report.Errors, fmt.Sprintf("error listing bucket contents: %v", err))
-	} else {
-		externalBucket.DirectoryContents = directoryContents
+	// Initialize bucket info
+	externalBucket := methodaws.ExternalBucket{
+		Name:   bucketName,
+		Region: region,
+		Url:    fmt.Sprintf("https://%s.s3.%s.amazonaws.com", bucketName, region),
 	}
 
-	// Check if listing is allowed
+	// Check if listing is allowed and get directory contents
 	externalBucket.AllowDirectoryListing = checkListingAllowed(ctx, client, bucketName)
-
-	// Check if anonymous read is allowed using the first object key, if available
-	externalBucket.AllowAnonymousRead = checkAnonymousReadAllowed(ctx, client, bucketName, directoryContents)
+	if externalBucket.AllowDirectoryListing {
+		directoryContents, err := listBucketContents(ctx, client, bucketName)
+		if err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("error listing bucket contents: %v", err))
+		} else {
+			externalBucket.DirectoryContents = directoryContents
+			// Check anonymous read access if we found any objects
+			externalBucket.AllowAnonymousRead = checkAnonymousReadAllowed(ctx, client, bucketName, directoryContents)
+		}
+	}
 
 	// Check bucket policy
 	policy, err := checkPolicy(ctx, client, bucketName)
@@ -208,29 +241,42 @@ func ExternalEnumerateS3Region(ctx context.Context, report methodaws.ExternalS3R
 	return report
 }
 
-// ExternalEnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials.
-// It checks regions one by one until it finds the bucket or exhausts all regions.
-func ExternalEnumerateS3(ctx context.Context, bucketName string, regions []string) methodaws.ExternalS3Report {
+// ExternalEnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials
+func ExternalEnumerateS3(ctx context.Context, bucketURL string, regions []string) methodaws.ExternalS3Report {
 	report := methodaws.ExternalS3Report{
 		ExternalBuckets: []*methodaws.ExternalBucket{},
 		Errors:          []string{},
 	}
 
-	for _, region := range regions {
+	// Parse the bucket URL to get name and potentially region
+	bucketName, urlRegion := parseBucketURL(bucketURL)
+
+	// If we got a region from the URL, only check that region
+	regionsToCheck := regions
+	if urlRegion != "" {
+		regionsToCheck = []string{urlRegion}
+	}
+
+	// For non-standard URLs, try the default region first
+	if !strings.Contains(bucketURL, "amazonaws.com") {
+		regionsToCheck = append([]string{"us-east-1"}, regionsToCheck...)
+	}
+
+	bucketFound := false
+	for _, region := range regionsToCheck {
 		exists, err := bucketExists(ctx, region, bucketName)
 		if err != nil {
 			report.Errors = append(report.Errors, fmt.Sprintf("Error checking bucket in region %s: %v", region, err))
 			continue
 		}
 		if exists {
-			r := ExternalEnumerateS3Region(ctx, report, bucketName, region)
-			report.Errors = append(report.Errors, r.Errors...)
-			report.ExternalBuckets = append(report.ExternalBuckets, r.ExternalBuckets...)
-			break // Stop checking other regions once we find the bucket
+			report = ExternalEnumerateS3Region(ctx, report, bucketName, region)
+			bucketFound = true
+			break
 		}
 	}
 
-	if len(report.ExternalBuckets) == 0 {
+	if !bucketFound {
 		report.Errors = append(report.Errors, "Bucket not found in any of the specified regions")
 	}
 

--- a/internal/s3/external.go
+++ b/internal/s3/external.go
@@ -12,6 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// isNonStandardS3URL checks if the URL follows standard S3 URL patterns
+func isNonStandardS3URL(url string) bool {
+	return !strings.Contains(url, "amazonaws.com") || !strings.Contains(url, "s3")
+}
+
 // parseBucketURL extracts bucket name and potentially region from S3 URL
 // Handles formats like:
 // - https://bucket-name.s3.region.amazonaws.com
@@ -22,8 +27,8 @@ func parseBucketURL(bucketURL string) (bucketName string, region string) {
 	bucketURL = strings.TrimPrefix(bucketURL, "https://")
 	bucketURL = strings.TrimPrefix(bucketURL, "http://")
 
-	// Handle non-standard URLs (e.g., https://image-api.fox.com)
-	if !strings.Contains(bucketURL, "amazonaws.com") {
+	// Handle non-standard URLs
+	if isNonStandardS3URL(bucketURL) {
 		return bucketURL, ""
 	}
 
@@ -268,7 +273,7 @@ func ExternalEnumerateS3(ctx context.Context, bucketURL string, regions []string
 	}
 
 	// For non-standard URLs, try the default region first
-	if !strings.Contains(bucketURL, "amazonaws.com") {
+	if isNonStandardS3URL(bucketURL) {
 		regionsToCheck = append([]string{"us-east-1"}, regionsToCheck...)
 	}
 


### PR DESCRIPTION
# Enhance S3 External Enumeration with URL Support

- Changed the S3 external enumeration command to accept URLs instead of bucket names
- Added URL parsing to handle various S3 URL formats (virtual-hosted style, path style)
- Added bucket owner information (ID and name) to the external bucket report
- Improved error handling and region detection from URLs
- Limited object listing to 100 keys to avoid overwhelming the API
- Added owner information fetching for both bucket and individual objects
- Optimized region checking by prioritizing regions detected from URLs