### PR TITLE
Fix S3 List Fern

### DIFF
--- a/fern/definition/s3/list.yml
+++ b/fern/definition/s3/list.yml
@@ -20,6 +20,6 @@ types:
   # Report
   S3ListReport:
     properties:
-      result: optional<ListResult>
+      result: ListResult
       config: ListS3BucketConfig
       errors: optional<list<string>>


### PR DESCRIPTION
### TL;DR

Updated the `result` field in `S3ListReport` to be required instead of optional.

### What changed?

Modified the `S3ListReport` type definition in `fern/definition/s3/list.yml` by changing the `result` property from `optional<ListResult>` to `ListResult`, making it a required field.

### How to test?

1. Verify that the API correctly returns a `ListResult` object in all responses
2. Check that any code handling the `S3ListReport` type doesn't assume the `result` field can be null/undefined
3. Ensure all existing implementations properly set the `result` field

### Why make this change?

This change enforces that all S3 list operations must return a result, improving type safety and making the API contract more predictable. It eliminates the need for null checks when accessing the `result` field, simplifying client code that consumes this API.