### PR TITLE
Route53 Enumerate Fern Fix

### DIFF
--- a/fern/definition/route53/enumerate.yml
+++ b/fern/definition/route53/enumerate.yml
@@ -47,7 +47,6 @@ types:
       continentCode: optional<string>
       countryCode: optional<string>
       subdivisionCode: optional<string>
-  # CIDR Routing struct
   CidrRouting:
     properties:
       collectionId: string
@@ -79,12 +78,12 @@ types:
     properties:
       zoneDetails: HostedZoneDetails
       resourceRecordSets: list<ResourceRecordSet>
-  Route53Resources:
+  Route53Result:
     properties:
       hostedZones: optional<list<EnrichedHostedZone>>
   # Route53 Enumeration Report
   Route53EnumerateReport:
     properties:
-      resources: Route53Resources
+      result: Route53Result
       config: Route53EnumerateConfig
       errors: optional<list<string>>

--- a/internal/route53/enumerate.go
+++ b/internal/route53/enumerate.go
@@ -231,8 +231,8 @@ func EnumerateRoute53(ctx context.Context, awscfg aws.Config) (*route53fern.Rout
 
 	// Initialize Report
 	report := route53fern.Route53EnumerateReport{
-		Resources: &route53fern.Route53Resources{},
-		Config:    &route53fern.Route53EnumerateConfig{AccountId: *accountID},
+		Result: &route53fern.Route53Result{},
+		Config: &route53fern.Route53EnumerateConfig{AccountId: *accountID},
 	}
 	var errors []string
 
@@ -249,19 +249,19 @@ func EnumerateRoute53(ctx context.Context, awscfg aws.Config) (*route53fern.Rout
 	}
 
 	// Add hosted zones to report
-	resources := route53fern.Route53Resources{}
+	result := route53fern.Route53Result{}
 	if len(hostedZones) > 0 {
 		// Convert to slice of pointers
 		var hostedZonePointers []*route53fern.EnrichedHostedZone
 		for i := range hostedZones {
 			hostedZonePointers = append(hostedZonePointers, &hostedZones[i])
 		}
-		resources.HostedZones = hostedZonePointers
+		result.HostedZones = hostedZonePointers
 	}
 
 	// Only add hosted zones if there are any
-	if len(resources.HostedZones) > 0 {
-		report.Resources.HostedZones = resources.HostedZones
+	if len(result.HostedZones) > 0 {
+		report.Result.HostedZones = result.HostedZones
 	}
 	report.Errors = errors
 	return &report, nil


### PR DESCRIPTION
### TL;DR

Renamed the `resources` field to `report` in the `Route53EnumerateReport` type and removed a comment.

### What changed?

- Renamed the `resources` property to `report` in the `Route53EnumerateReport` type definition
- Removed the comment `# CIDR Routing struct` that was above the `CidrRouting` type definition