### PR TITLE
CI Update: Arm Runner

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -16,19 +16,54 @@ env:
   GO_VERSION: "1.24"
 
 jobs:
-  prepare-linux:
-    name: Prepare Linux
+  prepare-linux-arm:
+    name: Prepare Linux (arm64)
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
+      - uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Generate Fern Go Code
+        run: |
+          npm install -g fern-api
+          fern generate --group local
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            build --single-target --clean --snapshot --timeout 60m
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GOOS: linux
+          GOARCH: arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-dist
+          path: dist/
+          retention-days: 7
+
+  prepare-linux-amd64:
+    name: Prepare Linux (amd64)
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
@@ -40,33 +75,25 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-
-      - name: Build ARM64 Builder Image
-        shell: bash
-        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
-
       - name: Build AMD64 Builder Image
-        shell: bash
         run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
-
-      - name: Build ARM64 Image
-        shell: bash
-        run: docker run -v .:/app/methodaws -e GOARCH=arm64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm armbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
-
       - name: Build AMD64 Image
-        shell: bash
-        run: docker run -v .:/app/methodaws -e GOARCH=amd64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm amdbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
-
+        run: |
+          docker run -v $PWD:/app/methodaws \
+            -e GOARCH=amd64 -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm amdbuilder goreleaser build --single-target \
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-dist
+          name: linux-amd64-dist
           path: dist/
           retention-days: 7
 
@@ -142,7 +169,8 @@ jobs:
     name: Build
     needs:
       - prepare
-      - prepare-linux
+      - prepare-linux-arm
+      - prepare-linux-amd64
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -219,10 +247,9 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
-          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -5,8 +5,11 @@ version: 2
 
 project_name: methodaws
 
+partial:
+  by: target
+
 builds:
-  - id: build-linux
+  - id: build-linux-amd64
     main: .
     binary: methodaws
     ldflags:
@@ -14,12 +17,25 @@ builds:
       - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/methodaws/main.version={{.Version}}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    goarm:
+      - "7"
+  - id: build-linux-arm64
+    main: .
+    binary: methodaws
+    ldflags:
+      - -s -w
+      - -X github.com/method-security/methodaws/main.version={{.Version}}
+    env:
+      - CGO_ENABLED=1
     goos:
       - linux
     goarch:
       - arm64
-      - amd64
     goarm:
       - "7"
   - id: build-macos


### PR DESCRIPTION
### TL;DR

Split Linux build process into separate ARM64 and AMD64 workflows for improved reliability and performance.

### What changed?

- Replaced the single `prepare-linux` job with two separate jobs: `prepare-linux-arm` and `prepare-linux-amd64`
- `prepare-linux-arm` now runs natively on an ARM64 runner (`ubuntu-22.04-arm`) instead of using QEMU emulation
- Removed Docker-based cross-compilation for ARM64 builds in favor of native compilation
- Updated the GoReleaser configuration to use separate build IDs for each architecture
- Enabled CGO for both architectures (changed from `CGO_ENABLED=0` to `CGO_ENABLED=1`)
- Updated artifact paths and naming conventions in the build job to match the new structure

### How to test?

1. Run the GitHub workflow to verify both ARM64 and AMD64 builds complete successfully
2. Verify the artifacts are correctly generated and organized in the output directories
3. Test the built binaries on their respective architectures to ensure they function properly

### Why make this change?

This change improves build reliability and performance by:
1. Using native ARM64 runners instead of emulation, which should be faster and more reliable
2. Separating the build processes to isolate potential architecture-specific issues
3. Enabling CGO for both architectures to support native dependencies
4. Simplifying the build process by removing the Docker-based cross-compilation approach