### PR TITLE
Update S3 External 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,11 +79,13 @@ func (a *MethodAws) setupCommonConfig(cmd *cobra.Command, outputFormat string, o
 			return err
 		}
 		a.AwsConfig = &awsConfig
-		a.RootFlags.Regions, err = common.GetAWSRegions(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
-		if err != nil || len(a.RootFlags.Regions) == 0 {
-			a.OutputSignal.Status = 1
-			a.OutputSignal.ErrorMessage = aws.String("No valid AWS regions found or specified")
-			return nil
+		if len(a.RootFlags.Regions) != 0 {
+			a.RootFlags.Regions, err = common.GetAWSRegions(cmd.Context(), *a.AwsConfig, a.RootFlags.Regions)
+			if err != nil {
+				a.OutputSignal.Status = 1
+				a.OutputSignal.ErrorMessage = aws.String("No valid AWS regions specified")
+				return errors.New("no valid AWS regions specified")
+			}
 		}
 	} else {
 		a.RootFlags.Regions = common.GetRegionsToCheck(cmd.Context(), a.RootFlags.Regions)
@@ -127,7 +129,7 @@ func (a *MethodAws) InitRootCommand() {
 
 	a.RootCmd.PersistentFlags().BoolVarP(&a.RootFlags.Quiet, "quiet", "q", false, "Suppress output")
 	a.RootCmd.PersistentFlags().BoolVarP(&a.RootFlags.Verbose, "verbose", "v", false, "Verbose output")
-	a.RootCmd.PersistentFlags().StringArrayVarP(&a.RootFlags.Regions, "regions", "r", []string{"us-east-1"}, "AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.")
+	a.RootCmd.PersistentFlags().StringArrayVarP(&a.RootFlags.Regions, "regions", "r", []string{}, "AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.")
 	a.RootCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "f", "", "Path to output file. If blank, will output to STDOUT")
 	a.RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "signal", "Output format (signal, json, yaml). Default value is signal")
 

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -8,6 +8,7 @@ import (
 
 	// Generated
 	s3fern "github.com/Method-Security/methodaws/generated/go/s3"
+	external "github.com/Method-Security/methodaws/internal/s3/external"
 )
 
 // InitS3Command initializes the `methodaws s3` subcommand that deals with enumerating S3 buckets and their related resources.
@@ -32,7 +33,7 @@ func (a *MethodAws) InitS3Command() {
 		Long:  `Enumerate all S3 buckets in your AWS account.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get Config
-			cfg := a.getS3EnumerateConfig(a.AwsConfig.Region, a.RootFlags.Regions)
+			cfg := a.getS3EnumerateConfig(a.RootFlags.Regions)
 
 			// Get Report
 			report, err := s3.EnumerateS3(cmd.Context(), *a.AwsConfig, cfg)
@@ -74,48 +75,66 @@ func (a *MethodAws) InitS3Command() {
 	// Flags
 	listCmd.Flags().String("name", "", "Name of the S3 bucket")
 
+	_ = listCmd.MarkFlagRequired("name")
+
 	// Add Command to S3 Command
 	s3Cmd.AddCommand(listCmd)
 
 	// External Command
-	externalEnumerateCmd := &cobra.Command{
+	externalCmd := &cobra.Command{
 		Use:   "external",
 		Short: "Enumerate a single public facing S3 bucket from an external prespective.",
 		Long:  `Enumerate a single public facing S3 bucket from an external prespective.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Override parent's PersistentPreRunE to use authed=false since external command uses anonymous credentials
+			outputFormat, _ := cmd.Root().PersistentFlags().GetString("output")
+			outputFile, _ := cmd.Root().PersistentFlags().GetString("output-file")
+			return a.setupCommonConfig(cmd, outputFormat, outputFile, false)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			bucketURL, err := cmd.Flags().GetString("url")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 
-			regions := a.RootFlags.Regions
-			if len(regions) == 0 || regions[0] == "all" {
+			// Check if specific region was provided via --region flag
+			// Override to not use the default region from the root command (us-east-1)
+			regionFlag, err := cmd.Flags().GetString("region")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			var regions []string
+			if regionFlag != "" {
+				// Use specific region if provided
+				regions = []string{regionFlag}
+			} else {
+				// Default to all regions for external command (override root default of us-east-1)
 				regions = utils.GetGeneralRegions()
 			}
 
 			config := getExternalS3BucketConfig(regions, bucketURL)
-			report := s3.ExternalEnumerateS3(cmd.Context(), config)
+			report := external.EnumerateS3(cmd.Context(), config)
 			a.OutputSignal.Content = report
 		},
 	}
 
 	// Flags
-	externalEnumerateCmd.Flags().String("url", "", "URL of the S3 bucket")
+	externalCmd.Flags().String("url", "", "URL of the S3 bucket")
+	externalCmd.Flags().String("region", "", "Region of the S3 bucket")
 
-	_ = externalEnumerateCmd.MarkFlagRequired("url")
+	_ = externalCmd.MarkFlagRequired("url")
 
 	// Add Command to S3 Command
-	s3Cmd.AddCommand(externalEnumerateCmd)
+	s3Cmd.AddCommand(externalCmd)
 
 	// Add S3 Command to Root Command
 	a.RootCmd.AddCommand(s3Cmd)
 }
 
-// getS3EnumerateConfig returns a s3fern.S3EnumerateConfig with the given account ID and regions
-func (a *MethodAws) getS3EnumerateConfig(accountID string, regions []string) s3fern.S3EnumerateConfig {
+// getS3EnumerateConfig returns a s3fern.S3EnumerateConfig with the given regions
+func (a *MethodAws) getS3EnumerateConfig(regions []string) s3fern.S3EnumerateConfig {
 	return s3fern.S3EnumerateConfig{
 		Regions: regions,
 	}

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -143,8 +143,8 @@ func (a *MethodAws) getS3EnumerateConfig(regions []string) s3fern.S3EnumerateCon
 // getExternalS3BucketConfig returns a s3fern.ExternalS3BucketConfig with the given regions and bucket URL
 func getExternalS3BucketConfig(regions []string, bucketURL string) s3fern.S3ExternalConfig {
 	return s3fern.S3ExternalConfig{
-		BucketUrl: bucketURL,
-		Regions:   regions,
+		Url:     bucketURL,
+		Regions: regions,
 	}
 }
 

--- a/fern/definition/s3/external.yml
+++ b/fern/definition/s3/external.yml
@@ -4,7 +4,7 @@ types:
   # Config
   S3ExternalConfig:
     properties:
-      bucketURL: string
+      url: string
       regions: optional<list<string>>
   # Report structs
   S3ObjectDetails:

--- a/internal/s3/enumerate.go
+++ b/internal/s3/enumerate.go
@@ -189,6 +189,7 @@ func EnumerateS3(ctx context.Context, awscfg aws.Config, config s3fern.S3Enumera
 			continue
 		}
 
+		// If the region is empty, set it to us-east-1
 		s3Bucket.Region = string(regionOutput.LocationConstraint)
 		if s3Bucket.Region == "" {
 			s3Bucket.Region = "us-east-1"

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -260,14 +260,14 @@ func externalS3Region(ctx context.Context, bucketURL string, bucketName string, 
 // EnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials
 func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.ExternalS3Report {
 	log := svc1log.FromContext(ctx)
-	log.Info("Starting external S3 enumeration", svc1log.SafeParam("bucketURL", config.BucketUrl))
+	log.Info("Starting external S3 enumeration", svc1log.SafeParam("bucketURL", config.Url))
 
 	report := s3fern.ExternalS3Report{Config: &config}
 	result := s3fern.ExternalS3BucketResult{}
 	errors := []string{}
 
 	// Parse the bucket URL to get name and potentially region
-	bucketName, urlRegion := parseBucketURL(config.BucketUrl)
+	bucketName, urlRegion := parseBucketURL(config.Url)
 
 	// If we got a region from the URL, only check that region
 	// By defaults tries us-ea
@@ -291,7 +291,7 @@ func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.Ext
 			log.Info("Found bucket in region",
 				svc1log.SafeParam("bucketName", bucketName),
 				svc1log.SafeParam("region", region))
-			functionResult, functionErrors := externalS3Region(ctx, config.BucketUrl, bucketName, region)
+			functionResult, functionErrors := externalS3Region(ctx, config.Url, bucketName, region)
 			if functionResult != nil {
 				result = *functionResult
 			}

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -15,55 +15,6 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// isNonStandardS3URL checks if the URL follows standard S3 URL patterns
-func isNonStandardS3URL(url string) bool {
-	return !strings.Contains(url, "amazonaws.com") || !strings.Contains(url, "s3")
-}
-
-// parseBucketURL extracts bucket name and potentially region from S3 URL
-// Handles formats like:
-// - https://bucket-name.s3.region.amazonaws.com
-// - https://s3.region.amazonaws.com/bucket-name
-// - bucket-name.s3.region.amazonaws.com
-func parseBucketURL(bucketURL string) (bucketName string, region string) {
-	// Clean Bucket URL
-	// Remove protocol if present
-	bucketURL = strings.TrimPrefix(bucketURL, "https://")
-	bucketURL = strings.TrimPrefix(bucketURL, "http://")
-	bucketURL = strings.Split(bucketURL, ":")[0]
-
-	// Handle non-standard URLs
-	if isNonStandardS3URL(bucketURL) {
-		return bucketURL, ""
-	}
-
-	// Parse standard S3 URLs
-	if strings.Contains(bucketURL, "/") {
-		// Format: s3.region.amazonaws.com/bucket-name
-		parts := strings.SplitN(bucketURL, "/", 2)
-		bucketName = parts[1]
-		hostParts := strings.Split(parts[0], ".")
-		if len(hostParts) >= 4 && hostParts[0] == "s3" {
-			region = hostParts[1]
-		}
-	} else {
-		// Format: bucket-name.s3.region.amazonaws.com
-		parts := strings.Split(bucketURL, ".")
-		if len(parts) >= 5 {
-			bucketName = parts[0]
-			if parts[1] == "s3" {
-				region = parts[2]
-			}
-		}
-	}
-
-	// Clean up bucket name
-	bucketName = strings.Split(bucketName, "?")[0]
-	bucketName = strings.TrimRight(bucketName, "/")
-
-	return bucketName, region
-}
-
 // bucketExists checks if a bucket exists and is accessible
 func bucketExists(ctx context.Context, region string, bucketName string) (bool, error) {
 	log := svc1log.FromContext(ctx)
@@ -224,8 +175,8 @@ func checkACL(ctx context.Context, client *s3.Client, bucketName string) ([]*s3f
 	return acls, ownerID, ownerName, nil
 }
 
-// ExternalEnumerateS3Region enumerates a single public facing S3 bucket in a specific region
-func externalEnumerateS3Region(ctx context.Context, bucketURL string, bucketName string, region string) (*s3fern.ExternalS3BucketResult, []string) {
+// EnumerateS3Region enumerates a single public facing S3 bucket in a specific region
+func externalS3Region(ctx context.Context, bucketURL string, bucketName string, region string) (*s3fern.ExternalS3BucketResult, []string) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting external S3 bucket enumeration",
 		svc1log.SafeParam("bucketName", bucketName),
@@ -306,8 +257,8 @@ func externalEnumerateS3Region(ctx context.Context, bucketURL string, bucketName
 	return &report, errors
 }
 
-// ExternalEnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials
-func ExternalEnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.ExternalS3Report {
+// EnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials
+func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.ExternalS3Report {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting external S3 enumeration", svc1log.SafeParam("bucketURL", config.BucketUrl))
 
@@ -319,14 +270,10 @@ func ExternalEnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3
 	bucketName, urlRegion := parseBucketURL(config.BucketUrl)
 
 	// If we got a region from the URL, only check that region
+	// By defaults tries us-ea
 	regionsToCheck := config.Regions
 	if urlRegion != "" {
 		regionsToCheck = []string{urlRegion}
-	}
-
-	// For non-standard URLs, try the default region first
-	if isNonStandardS3URL(config.BucketUrl) {
-		regionsToCheck = append([]string{"us-east-1"}, regionsToCheck...)
 	}
 
 	bucketFound := false
@@ -344,7 +291,7 @@ func ExternalEnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3
 			log.Info("Found bucket in region",
 				svc1log.SafeParam("bucketName", bucketName),
 				svc1log.SafeParam("region", region))
-			functionResult, functionErrors := externalEnumerateS3Region(ctx, config.BucketUrl, bucketName, region)
+			functionResult, functionErrors := externalS3Region(ctx, config.BucketUrl, bucketName, region)
 			if functionResult != nil {
 				result = *functionResult
 			}

--- a/internal/s3/external/helpers.go
+++ b/internal/s3/external/helpers.go
@@ -1,0 +1,210 @@
+package s3
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// parseBucketURL extracts the S3 bucket name and (if derivable) the region
+// from common S3 URL forms and custom domains (CNAMEs) pointing to S3.
+//
+// Supported examples:
+//   - https://bucket.s3.us-east-1.amazonaws.com
+//   - https://bucket.s3.amazonaws.com
+//   - https://sub.domain.bucket.s3.us-east-1.amazonaws.com (buckets with subdomains)
+//   - https://s3.us-east-1.amazonaws.com/bucket
+//   - https://s3.amazonaws.com/bucket
+//   - http://bucket.s3-website-us-east-1.amazonaws.com
+//   - https://bucket.s3-accelerate.amazonaws.com
+//   - https://custom-domain.example.com (CNAME to S3)
+//   - (no scheme) bucket.s3.us-west-2.amazonaws.com
+//
+// Region rules:
+//   - Virtual-hosted regional (bucket.s3.<region>.*) → region extracted
+//   - Path-style regional (s3.<region>.* /bucket)   → region extracted
+//   - Global endpoints (s3.amazonaws.com, s3-accelerate) → region empty
+//   - Website endpoints (s3-website-<region>) → region extracted
+//   - Custom domains → region empty (not derivable from URL)
+//
+// Returns: (bucketName, region). Region may be "" if not derivable.
+func parseBucketURL(raw string) (string, string) {
+	if raw == "" {
+		return "", ""
+	}
+
+	// Ensure we can parse even if scheme is missing
+	u := ensureURL(raw)
+
+	// Strip userinfo, port; isolate host labels and first path segment
+	host := strings.ToLower(u.Host)
+	if host == "" {
+		return "", ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	labels := strings.Split(host, ".")
+
+	// Check if this is a standard AWS endpoint
+	isAwsEndpoint := false
+	if len(labels) >= 2 {
+		domain := strings.Join(labels[len(labels)-2:], ".") // "amazonaws.com" or "amazonaws.com.cn"
+		if domain == "amazonaws.com" || domain == "amazonaws.com.cn" {
+			isAwsEndpoint = true
+		}
+	}
+
+	// If not a standard AWS endpoint, treat as custom domain (CNAME) pointing to S3
+	if !isAwsEndpoint {
+		// For custom domains, the entire host is typically the bucket name
+		// and we can't determine the region from the URL
+		return cleanupBucket(host), ""
+	}
+
+	// For AWS endpoints, ensure we have enough labels to process
+	if len(labels) < 3 {
+		return "", ""
+	}
+
+	// First path segment (for path-style)
+	pathSeg := firstPathSegment(u.Path)
+
+	// ----- Patterns -----
+
+	// 1) Path-style regional: s3.<region>.amazonaws.com / bucket
+	//    Also handles dualstack: s3.dualstack.<region>.amazonaws.com / bucket
+	if labels[0] == "s3" || (labels[0] == "s3" && len(labels) >= 2 && labels[1] == "dualstack") || labels[0] == "s3-dualstack" {
+		if pathSeg == "" {
+			return "", ""
+		}
+		region := ""
+		// s3.<region>....  -> region is labels[1]
+		// s3.dualstack.<region>.... OR s3-dualstack.<region>.... -> region is labels[2]
+		if labels[0] == "s3" && len(labels) >= 4 && labels[1] != "amazonaws" {
+			region = labels[1]
+		} else if (labels[0] == "s3" && len(labels) >= 5 && labels[1] == "dualstack") ||
+			(labels[0] == "s3-dualstack" && len(labels) >= 5) {
+			// s3.dualstack.<region>.amazonaws.com
+			// s3-dualstack.<region>.amazonaws.com
+			region = labels[2]
+		} else {
+			// Global path-style (s3.amazonaws.com / bucket) or unrecognized
+			region = ""
+		}
+		return cleanupBucket(pathSeg), region
+	}
+
+	// Check for virtual-hosted style by finding .s3. pattern
+	// This handles bucket names with subdomains like sub.domain.bucket.s3.region.amazonaws.com
+	s3Index := findS3Index(labels)
+	if s3Index >= 0 {
+		// Extract bucket name (everything before .s3.)
+		bucketParts := labels[:s3Index]
+		bucket := strings.Join(bucketParts, ".")
+
+		// Check what comes after .s3.
+		if s3Index+1 < len(labels) {
+			// 2) Virtual-hosted, regional: bucket.s3.<region>.amazonaws.com
+			if s3Index+3 < len(labels) && labels[s3Index+2] == "amazonaws" {
+				region := labels[s3Index+1]
+				return cleanupBucket(bucket), region
+			}
+			// 3) Virtual-hosted, global: bucket.s3.amazonaws.com
+			if s3Index+2 < len(labels) && labels[s3Index+1] == "amazonaws" {
+				return cleanupBucket(bucket), ""
+			}
+		}
+	}
+
+	// 4) Website endpoints: bucket.s3-website-<region>.amazonaws.com
+	//    Look for s3-website- pattern in any label position (to handle bucket subdomains)
+	for i, label := range labels {
+		if strings.HasPrefix(label, "s3-website-") {
+			if i >= 1 && i+2 < len(labels) && labels[i+1] == "amazonaws" {
+				bucketParts := labels[:i]
+				bucket := strings.Join(bucketParts, ".")
+				region := strings.TrimPrefix(label, "s3-website-")
+				return cleanupBucket(bucket), region
+			}
+		}
+	}
+
+	// 5) Accelerate endpoints: bucket.s3-accelerate.amazonaws.com (or ...dualstack...)
+	//    Look for s3-accelerate pattern in any label position (to handle bucket subdomains)
+	for i, label := range labels {
+		if label == "s3-accelerate" || strings.HasPrefix(label, "s3-accelerate") {
+			if i >= 1 && i+2 < len(labels) && labels[i+1] == "amazonaws" {
+				bucketParts := labels[:i]
+				bucket := strings.Join(bucketParts, ".")
+				return cleanupBucket(bucket), ""
+			}
+		}
+	}
+
+	// 6) Legacy global path-style: s3.amazonaws.com/bucket
+	if strings.EqualFold(host, "s3.amazonaws.com") || strings.EqualFold(host, "s3-external-1.amazonaws.com") {
+		if pathSeg == "" {
+			return "", ""
+		}
+		return cleanupBucket(pathSeg), ""
+	}
+
+	// Not recognized as S3 bucket URL
+	return "", ""
+}
+
+func ensureURL(raw string) *url.URL {
+	// Add scheme if missing so url.Parse sees Host
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		// Fallback minimal parse
+		return &url.URL{Host: raw}
+	}
+	return u
+}
+
+func firstPathSegment(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return ""
+	}
+	seg := p
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		seg = p[:i]
+	}
+	// ignore query/fragment (already stripped by url.Parse)
+	return seg
+}
+
+// findS3Index finds the index of "s3" label in virtual-hosted style URLs
+// Returns -1 if "s3" is not found at an appropriate position
+func findS3Index(labels []string) int {
+	for i, label := range labels {
+		if label == "s3" {
+			// Make sure this is a virtual-hosted pattern, not a path-style one
+			// Virtual-hosted: bucket[.subdomain].s3[.region].amazonaws.com
+			// Path-style: s3[.region].amazonaws.com/bucket
+			if i > 0 { // s3 should not be the first label for virtual-hosted
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func cleanupBucket(b string) string {
+	// Defensive cleanup; bucket DNS-style names shouldn't contain '?' or trailing '/'
+	b = strings.TrimSpace(b)
+	b = strings.TrimSuffix(b, "/")
+	if i := strings.IndexByte(b, '?'); i >= 0 {
+		b = b[:i]
+	}
+	return b
+}


### PR DESCRIPTION
### TL;DR

Improved S3 bucket URL parsing and fixed region handling for the S3 external command.

### What changed?

- Fixed region handling in the root command to avoid errors when no regions are specified
- Moved S3 external functionality to a dedicated package (`internal/s3/external`)
- Enhanced bucket URL parsing with comprehensive support for various S3 URL formats
- Made the S3 external command use anonymous credentials by overriding the parent's authentication
- Added a region flag to the S3 external command to allow specifying a specific region
- Improved error messaging for invalid AWS regions