### PR TITLE
Clean Up Big Fern Update

### DIFF
--- a/fern/definition/cloudfront/enumerate.yml
+++ b/fern/definition/cloudfront/enumerate.yml
@@ -36,8 +36,8 @@ types:
 # CloudFront Distribution High level Structs
   CloudFrontDistributionIdentificationInfo:
     properties:
-      id: string
-      arn: optional<string>
+      arn: string
+      id: optional<string>
       domainName: optional<string>
   CloudFrontDistributionConfigurationInfo:
     properties:

--- a/fern/definition/ec2/enumerate.yml
+++ b/fern/definition/ec2/enumerate.yml
@@ -95,6 +95,7 @@ types:
   Ec2InstanceIdentificationInfo:
     properties:
       id: string
+      name: optional<string>
       region: string
   Ec2InstanceConfigurationInfo:
     properties:
@@ -112,12 +113,12 @@ types:
       hypervisor: optional<HypervisorType>
       platform: optional<PlatformValues>
       ebsOptimized: optional<boolean>
-      name: optional<string>
       tags: optional<list<Tag>>
   Ec2InstanceResourceInfo:
     properties:
       networkInterfaces: optional<list<InstanceNetworkInterface>>
       iamInstanceProfile: optional<IamInstanceProfile>
+      securityGroupIds: optional<list<string>>
 # EC2 Main Structs
   Ec2Instance:
     properties:

--- a/fern/definition/lambda/enumerate.yml
+++ b/fern/definition/lambda/enumerate.yml
@@ -17,7 +17,6 @@ types:
     properties:
       vpcId: string
       subnetIds: list<string>
-      securityGroupIds: list<string>
   LambdaLoggingFormat:
     enum:
       - TEXT
@@ -51,6 +50,7 @@ types:
     properties:
       vpc: optional<LambdaVpcConfig>
       iamRoleArn: string
+      securityGroupIds: list<string>
 # Lambda Main Structs
   LambdaFunction:
     properties:

--- a/fern/definition/loadbalancer/enumerate.yml
+++ b/fern/definition/loadbalancer/enumerate.yml
@@ -99,12 +99,11 @@ types:
 # LoadBalancer High level structs
   LoadBalancerIdentificationInfo:
     properties:
-      id: string
-      arn: optional<string>
+      arn: optional<string> # Only for ELB v2
+      name: optional<string> # Needed for ELB v1
       region: string
   LoadBalancerConfigurationInfo:
     properties:
-      name: optional<string>
       loadBalancerType: LoadBalancerType
       dnsName: optional<string>
       createdTime: optional<datetime>

--- a/fern/definition/rds/enumerate.yml
+++ b/fern/definition/rds/enumerate.yml
@@ -42,21 +42,15 @@ types:
       copyTagsToSnapshot: optional<boolean>
       latestRestorableTime: optional<datetime>
 # VPC High level structs
-  VpcIdentificationInfo:
-    properties:
-      id: string
-  VpcResourceInfo:
-    properties:
-      subnetIds: optional<list<string>>
   VpcInstance:
     properties:
-      identification: VpcIdentificationInfo 
-      resources: optional<VpcResourceInfo>
+      id: string 
+      subnetIds: optional<list<string>>
 # RDS High level structs
   RdsIdentificationInfo:
     properties:
-      id: string
-      arn: optional<string>
+      arn: string
+      id: optional<string>
       name: optional<string>
       region: string
   RdsConfigurationInfo:

--- a/fern/definition/securitygroup/enumerate.yml
+++ b/fern/definition/securitygroup/enumerate.yml
@@ -33,10 +33,10 @@ types:
     properties:
       id: string
       arn: optional<string>
+      name: optional<string>
       region: string
   SecurityGroupConfigurationInfo:
     properties:
-      name: optional<string>
       description: optional<string>
       securityGroupType: SecurityGroupType
       ownerId: optional<string>

--- a/internal/cloudfront/enumerate/enumerate.go
+++ b/internal/cloudfront/enumerate/enumerate.go
@@ -66,9 +66,9 @@ func enumerateCloudFrontDistributions(ctx context.Context, awsConfig aws.Config,
 
 	var cloudFrontDistributions []*cloudfrontfern.CloudFrontDistribution
 	for _, dist := range distributions {
-		if dist.Id == nil {
-			log.Warn("Distribution ID is nil for distribution", svc1log.SafeParam("distribution", dist))
-			errors = append(errors, "Distribution ID is nil")
+		if dist.ARN == nil {
+			log.Warn("Distribution ARN is nil for distribution", svc1log.SafeParam("distribution", dist))
+			errors = append(errors, "Distribution ARN is nil")
 			continue
 		}
 		distribution, errs := processDistribution(ctx, awsConfig, cloudfrontClient, dist, config.AccountId)

--- a/internal/cloudfront/enumerate/transformers.go
+++ b/internal/cloudfront/enumerate/transformers.go
@@ -47,8 +47,8 @@ func transformDistributionToFern(ctx context.Context, awsConfig aws.Config, dist
 	// Create distribution with nested structure
 	return &cloudfrontfern.CloudFrontDistribution{
 		Identification: &cloudfrontfern.CloudFrontDistributionIdentificationInfo{
-			Id:         aws.ToString(dist.Id),
-			Arn:        dist.ARN,
+			Arn:        *dist.ARN,
+			Id:         dist.Id,
 			DomainName: dist.DomainName,
 		},
 		Configuration: &cloudfrontfern.CloudFrontDistributionConfigurationInfo{
@@ -77,8 +77,8 @@ func transformDistributionSummaryToFern(ctx context.Context, awsConfig aws.Confi
 	// Create distribution with nested structure
 	return &cloudfrontfern.CloudFrontDistribution{
 		Identification: &cloudfrontfern.CloudFrontDistributionIdentificationInfo{
-			Id:         aws.ToString(dist.Id),
-			Arn:        dist.ARN,
+			Arn:        *dist.ARN,
+			Id:         dist.Id,
 			DomainName: dist.DomainName,
 		},
 		Configuration: &cloudfrontfern.CloudFrontDistributionConfigurationInfo{

--- a/internal/ec2/enumerate/converters.go
+++ b/internal/ec2/enumerate/converters.go
@@ -45,11 +45,18 @@ func convertInstanceToFern(ctx context.Context, awsInstance types.Instance, regi
 		networkInterfaces, errors = convertNetworkInterfaces(ctx, awsInstance.NetworkInterfaces, region)
 	}
 
+	// Extract security group IDs
+	var securityGroupIds []string
+	if len(awsInstance.SecurityGroups) > 0 {
+		securityGroupIds = extractSecurityGroupIds(awsInstance.SecurityGroups)
+	}
+
 	// Create instance with nested structure
 	instance := &ec2fern.Ec2Instance{
 		Identification: &ec2fern.Ec2InstanceIdentificationInfo{
 			Id:     *awsInstance.InstanceId,
 			Region: region,
+			Name:   name,
 		},
 		Configuration: &ec2fern.Ec2InstanceConfigurationInfo{
 			State:            state,
@@ -66,12 +73,12 @@ func convertInstanceToFern(ctx context.Context, awsInstance types.Instance, regi
 			Hypervisor:       convertHypervisor(awsInstance.Hypervisor),
 			Platform:         convertPlatform(awsInstance.Platform),
 			EbsOptimized:     awsInstance.EbsOptimized,
-			Name:             name,
 			Tags:             tags,
 		},
 		Resources: &ec2fern.Ec2InstanceResourceInfo{
 			NetworkInterfaces:  networkInterfaces,
 			IamInstanceProfile: iamInstanceProfile,
+			SecurityGroupIds:   securityGroupIds,
 		},
 	}
 
@@ -245,4 +252,17 @@ func extractNameFromTags(tags []types.Tag) *string {
 		}
 	}
 	return nil
+}
+
+// extractSecurityGroupIds extracts security group IDs from AWS security groups
+func extractSecurityGroupIds(securityGroups []types.GroupIdentifier) []string {
+	var securityGroupIds []string
+
+	for _, sg := range securityGroups {
+		if sg.GroupId != nil {
+			securityGroupIds = append(securityGroupIds, *sg.GroupId)
+		}
+	}
+
+	return securityGroupIds
 }

--- a/internal/lambda/lambda.go
+++ b/internal/lambda/lambda.go
@@ -49,11 +49,13 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 	var vpcConfig *lambdafern.LambdaVpcConfig
 	if function.VpcConfig != nil {
 		vpcConfig = &lambdafern.LambdaVpcConfig{
-			VpcId:            *function.VpcConfig.VpcId,
-			SubnetIds:        function.VpcConfig.SubnetIds,
-			SecurityGroupIds: function.VpcConfig.SecurityGroupIds,
+			VpcId:     *function.VpcConfig.VpcId,
+			SubnetIds: function.VpcConfig.SubnetIds,
 		}
 	}
+
+	var securityGroupIds []string
+	securityGroupIds = append(securityGroupIds, function.VpcConfig.SecurityGroupIds...)
 
 	var loggingConfig *lambdafern.LambdaLoggingConfig
 	if function.LoggingConfig != nil {
@@ -111,8 +113,9 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 			LoggingConfig:        loggingConfig,
 		},
 		Resources: &lambdafern.LambdaResourceInfo{
-			Vpc:        vpcConfig,
-			IamRoleArn: *function.Role,
+			Vpc:              vpcConfig,
+			IamRoleArn:       *function.Role,
+			SecurityGroupIds: securityGroupIds,
 		},
 	}
 	return result, nil

--- a/internal/lambda/lambda.go
+++ b/internal/lambda/lambda.go
@@ -55,7 +55,9 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 	}
 
 	var securityGroupIds []string
-	securityGroupIds = append(securityGroupIds, function.VpcConfig.SecurityGroupIds...)
+	if function.VpcConfig != nil {
+		securityGroupIds = append(securityGroupIds, function.VpcConfig.SecurityGroupIds...)
+	}
 
 	var loggingConfig *lambdafern.LambdaLoggingConfig
 	if function.LoggingConfig != nil {

--- a/internal/loadbalancer/enumerate/elbv1.go
+++ b/internal/loadbalancer/enumerate/elbv1.go
@@ -68,13 +68,12 @@ func enumerateV1LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 
 			// Create identification info
 			identification := &loadbalancerfern.LoadBalancerIdentificationInfo{
-				Id:     aws.ToString(lb.LoadBalancerName),
+				Name:   lb.LoadBalancerName,
 				Region: region,
 			}
 
 			// Create configuration info
 			configuration := &loadbalancerfern.LoadBalancerConfigurationInfo{
-				Name:             lb.LoadBalancerName,
 				LoadBalancerType: loadbalancerfern.LoadBalancerTypeClassic,
 				DnsName:          lb.DNSName,
 				CreatedTime:      lb.CreatedTime,

--- a/internal/loadbalancer/enumerate/elbv2.go
+++ b/internal/loadbalancer/enumerate/elbv2.go
@@ -74,7 +74,7 @@ func enumerateV2LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 		}
 
 		for _, lb := range page.LoadBalancers {
-			if lb.LoadBalancerName == nil {
+			if lb.LoadBalancerArn == nil {
 				log.Warn("LoadBalancer name is nil for load balancer", svc1log.SafeParam("loadBalancer", lb))
 				errorMessages = append(errorMessages, "LoadBalancer name is nil")
 				continue
@@ -82,14 +82,13 @@ func enumerateV2LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 
 			// Create identification info
 			identification := &loadbalancerfern.LoadBalancerIdentificationInfo{
-				Id:     aws.ToString(lb.LoadBalancerName),
 				Arn:    lb.LoadBalancerArn,
+				Name:   lb.LoadBalancerName,
 				Region: region,
 			}
 
 			// Create configuration info
 			configuration := &loadbalancerfern.LoadBalancerConfigurationInfo{
-				Name:         lb.LoadBalancerName,
 				DnsName:      lb.DNSName,
 				CreatedTime:  lb.CreatedTime,
 				HostedZoneId: lb.CanonicalHostedZoneId,
@@ -121,12 +120,12 @@ func enumerateV2LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 			}
 
 			// Get listeners and target groups
-			listeners, errors := listenersForLoadBalancerV2(ctx, client, identification.Arn)
+			listeners, errors := listenersForLoadBalancerV2(ctx, client, lb.LoadBalancerArn)
 			if len(errors) > 0 {
 				errorMessages = append(errorMessages, errors...)
 			}
 
-			targetGroups, errors := targetGroupForLoadBalancerV2(ctx, client, identification.Arn, region)
+			targetGroups, errors := targetGroupForLoadBalancerV2(ctx, client, lb.LoadBalancerArn, region)
 			if len(errors) > 0 {
 				errorMessages = append(errorMessages, errors...)
 			}

--- a/internal/rds/enumerate.go
+++ b/internal/rds/enumerate.go
@@ -72,7 +72,7 @@ func enumerateRDSForRegion(ctx context.Context, awsConfig aws.Config, region str
 	// List RDS instances
 	instances, err := listRDSInstances(ctx, rdsClient)
 	if err != nil {
-		errorMsg := "Failed to list RDS instances: " + err.Error()
+		errorMsg := "Failed to list RDS instances in region " + region + ": " + err.Error()
 		log.Error("Error listing RDS instances", svc1log.SafeParam("error", err.Error()))
 		errors = append(errors, errorMsg)
 		return nil, errors
@@ -83,9 +83,9 @@ func enumerateRDSForRegion(ctx context.Context, awsConfig aws.Config, region str
 	var rdsInstances []*rdsfern.RdsInstance
 	for _, instance := range instances {
 		// Check for required DBInstanceIdentifier
-		if instance.DBInstanceIdentifier == nil {
-			log.Warn("RDS DB Instance Identifier is nil", svc1log.SafeParam("instance", instance))
-			errors = append(errors, "RDS DB Instance Identifier is nil")
+		if instance.DBInstanceArn == nil {
+			log.Warn("RDS DB Instance ARN is nil", svc1log.SafeParam("instance", instance))
+			errors = append(errors, "RDS DB Instance ARN is nil")
 			continue
 		}
 
@@ -125,8 +125,8 @@ func convertAWSDBInstanceToFern(instance types.DBInstance, region string) (*rdsf
 	}
 	dbInstance := &rdsfern.RdsInstance{
 		Identification: &rdsfern.RdsIdentificationInfo{
-			Id:     *instance.DBInstanceIdentifier,
-			Arn:    instance.DBInstanceArn,
+			Arn:    *instance.DBInstanceArn,
+			Id:     instance.DBInstanceIdentifier,
 			Name:   instance.DBName,
 			Region: region,
 		},
@@ -140,6 +140,7 @@ func convertAWSDBInstanceToFern(instance types.DBInstance, region string) (*rdsf
 			MultiAz:            instance.MultiAZ,
 			PubliclyAccessible: instance.PubliclyAccessible,
 		},
+		Resources: &rdsfern.RdsResourceInfo{},
 	}
 
 	// Network & Availability
@@ -166,20 +167,12 @@ func convertAWSDBInstanceToFern(instance types.DBInstance, region string) (*rdsf
 			}
 		}
 
-		vpc := &rdsfern.VpcInstance{
-			Identification: &rdsfern.VpcIdentificationInfo{
-				Id: *instance.DBSubnetGroup.VpcId,
-			},
-			Resources: &rdsfern.VpcResourceInfo{
+		if instance.DBSubnetGroup.VpcId != nil {
+			dbInstance.Resources.Vpc = &rdsfern.VpcInstance{
+				Id:        *instance.DBSubnetGroup.VpcId,
 				SubnetIds: subnetIds,
-			},
+			}
 		}
-
-		// Initialize resources if not already initialized
-		if dbInstance.Resources == nil {
-			dbInstance.Resources = &rdsfern.RdsResourceInfo{}
-		}
-		dbInstance.Resources.Vpc = vpc
 	}
 
 	// Storage Configuration

--- a/internal/route53/enumerate.go
+++ b/internal/route53/enumerate.go
@@ -39,6 +39,7 @@ func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]rout
 
 		for _, hostedZone := range page.HostedZones {
 			// Prepare identification info
+			// These always exist
 			identification := &route53fern.HostedZoneIdentificationInfo{
 				CallerReference: *hostedZone.CallerReference,
 				Id:              *hostedZone.Id,

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -228,9 +228,9 @@ func convertAWSEC2SecurityGroupToFern(awsSG ec2types.SecurityGroup, region strin
 		Identification: &fernsecuritygroup.SecurityGroupIdentificationInfo{
 			Id:     *awsSG.GroupId,
 			Region: region,
+			Name:   awsSG.GroupName,
 		},
 		Configuration: &fernsecuritygroup.SecurityGroupConfigurationInfo{
-			Name:              awsSG.GroupName,
 			Description:       awsSG.Description,
 			SecurityGroupType: fernsecuritygroup.SecurityGroupTypeEc2,
 			OwnerId:           awsSG.OwnerId,
@@ -265,10 +265,10 @@ func convertAWSRDSSecurityGroupToFern(awsSG rdstypes.DBSecurityGroup, region str
 		Identification: &fernsecuritygroup.SecurityGroupIdentificationInfo{
 			Id:     *awsSG.DBSecurityGroupName,
 			Arn:    awsSG.DBSecurityGroupArn,
+			Name:   awsSG.DBSecurityGroupName,
 			Region: region,
 		},
 		Configuration: &fernsecuritygroup.SecurityGroupConfigurationInfo{
-			Name:              awsSG.DBSecurityGroupName,
 			Description:       awsSG.DBSecurityGroupDescription,
 			SecurityGroupType: fernsecuritygroup.SecurityGroupTypeRds,
 			OwnerId:           awsSG.OwnerId,


### PR DESCRIPTION
### TL;DR

Restructured AWS resource data models to improve consistency and better reflect AWS API responses.

### What changed?

- **CloudFront Distribution**: Changed `arn` to required and `id` to optional in identification info
- **EC2 Instance**:
    - Moved `name` from configuration to identification info
    - Added `securityGroupIds` to resource info
- **Lambda Function**:
    - Moved `securityGroupIds` from VPC config to resource info
- **Load Balancer**:
    - Changed identification structure to use `arn` for ELBv2 and `name` for ELBv1
    - Removed redundant `name` from configuration info
- **Security Group**:
    - Moved `name` from configuration to identification info

Updated corresponding Go implementation code to align with these model changes.