### PR TITLE
RDS Fern Update

### DIFF
--- a/fern/definition/rds/enumerate.yml
+++ b/fern/definition/rds/enumerate.yml
@@ -27,7 +27,6 @@ types:
       deletionProtection: optional<boolean>
       iamDatabaseAuthenticationEnabled: optional<boolean>
       kmsKeyId: optional<string>
-      vpcSecurityGroupIds: optional<list<string>>
   MonitoringConfig:
     properties:
       monitoringInterval: optional<integer>
@@ -76,6 +75,7 @@ types:
   RdsResourceInfo:
     properties:
       vpc: optional<VpcInstance>
+      securityGroupIds: optional<list<string>>
 # Main RDS Structs
   RdsInstance:
     properties:

--- a/internal/rds/enumerate.go
+++ b/internal/rds/enumerate.go
@@ -213,8 +213,10 @@ func convertAWSDBInstanceToFern(instance types.DBInstance, region string) (*rdsf
 		DeletionProtection:               instance.DeletionProtection,
 		IamDatabaseAuthenticationEnabled: instance.IAMDatabaseAuthenticationEnabled,
 		KmsKeyId:                         instance.KmsKeyId,
-		VpcSecurityGroupIds:              vpcSecurityGroupIds,
 	}
+
+	// Set security group IDs in Resources
+	dbInstance.Resources.SecurityGroupIds = vpcSecurityGroupIds
 
 	// Monitoring Configuration
 	var monitoringInterval *int


### PR DESCRIPTION
### TL;DR

Moved VPC security group IDs from `RdsInstanceConfig` to `RdsResourceInfo` for better organization.

### What changed?

- Removed `vpcSecurityGroupIds` field from the `RdsInstanceConfig` type in the Fern definition
- Added `securityGroupIds` field to the `RdsResourceInfo` type in the Fern definition
- Updated the Go implementation to store security group IDs in `Resources.SecurityGroupIds` instead of directly in the instance config
