### PR TITLE
Security Group Fern Update

### DIFF
--- a/fern/definition/securitygroup/enumerate.yml
+++ b/fern/definition/securitygroup/enumerate.yml
@@ -15,6 +15,10 @@ types:
       - INGRESS
       - EGRESS
 # Supporting Structs
+  ReferencedSecurityGroup:
+    properties:
+      groupId: string
+      userId: string
   Tag:
     properties:
       key: string
@@ -28,6 +32,7 @@ types:
       ipProtocol: optional<string>
       cidrs: optional<list<string>>
       description: optional<string>
+      referencedSecurityGroup: optional<ReferencedSecurityGroup>
   VpcInstance:
     properties:
       id: string

--- a/fern/definition/securitygroup/enumerate.yml
+++ b/fern/definition/securitygroup/enumerate.yml
@@ -50,7 +50,7 @@ types:
     properties:
       identification: SecurityGroupIdentificationInfo
       configuration: SecurityGroupConfigurationInfo
-      resources: optional<list<SecurityGroupResourceInfo>>
+      resources: optional<SecurityGroupResourceInfo>
   SecurityGroupsEnumerateResult:
     properties:
       securityGroups: optional<list<SecurityGroup>>

--- a/fern/definition/securitygroup/enumerate.yml
+++ b/fern/definition/securitygroup/enumerate.yml
@@ -21,10 +21,13 @@ types:
       value: string
   IpPermission:
     properties:
+      id: string
       direction: PermissionDirection
       fromPort: optional<integer>
       toPort: optional<integer>
       ipProtocol: optional<string>
+      cidrs: optional<list<string>>
+      description: optional<string>
   VpcInstance:
     properties:
       id: string

--- a/fern/definition/securitygroup/enumerate.yml
+++ b/fern/definition/securitygroup/enumerate.yml
@@ -23,16 +23,19 @@ types:
     properties:
       key: string
       value: string
-  IpPermission:
+  RulePeerInfo:
+    properties:
+      cidrs: optional<list<string>>
+      referencedSecurityGroup: optional<ReferencedSecurityGroup>
+  RuleDetails:
     properties:
       id: string
       direction: PermissionDirection
+      peer: RulePeerInfo
       fromPort: optional<integer>
       toPort: optional<integer>
       ipProtocol: optional<string>
-      cidrs: optional<list<string>>
       description: optional<string>
-      referencedSecurityGroup: optional<ReferencedSecurityGroup>
   VpcInstance:
     properties:
       id: string
@@ -52,7 +55,7 @@ types:
   SecurityGroupResourceInfo:
     properties:
       vpc: optional<VpcInstance>
-      rules: optional<list<IpPermission>>
+      rules: optional<list<RuleDetails>>
 # Main Security Group Structs
   SecurityGroup:
     properties:

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -16,6 +16,33 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// fetchSecurityGroupRules retrieves detailed rules for a specific security group
+func fetchSecurityGroupRules(ctx context.Context, cfg aws.Config, groupId string) ([]ec2types.SecurityGroupRule, error) {
+	svc := ec2.NewFromConfig(cfg)
+
+	input := &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: []string{groupId},
+			},
+		},
+	}
+
+	var allRules []ec2types.SecurityGroupRule
+	paginator := ec2.NewDescribeSecurityGroupRulesPaginator(svc, input)
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		allRules = append(allRules, output.SecurityGroupRules...)
+	}
+
+	return allRules, nil
+}
+
 // EnumerateSecurityGroups lists all of the security groups available to the caller across multiple regions
 // alongside any non-fatal errors that occurred during the execution of the `methodaws securitygroup enumerate` subcommand.
 // This includes both EC2/VPC security groups and RDS DB security groups.
@@ -56,7 +83,8 @@ func EnumerateSecurityGroups(ctx context.Context, cfg aws.Config, config fernsec
 				allErrors = append(allErrors, "EC2 SecurityGroup ID is nil")
 				continue
 			}
-			fernSG := convertAWSEC2SecurityGroupToFern(sg, region)
+			fernSG, errors := convertAWSEC2SecurityGroupToFern(ctx, cfg, sg, region)
+			allErrors = append(allErrors, errors...)
 			allSecurityGroups = append(allSecurityGroups, fernSG)
 		}
 
@@ -160,47 +188,75 @@ func enumerateRDSSecurityGroupForRegion(ctx context.Context, cfg aws.Config, reg
 }
 
 // convertAWSEC2SecurityGroupToFern converts an AWS SDK EC2 SecurityGroup to a Fern SecurityGroup
-func convertAWSEC2SecurityGroupToFern(awsSG ec2types.SecurityGroup, region string) *fernsecuritygroup.SecurityGroup {
+func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG ec2types.SecurityGroup, region string) (*fernsecuritygroup.SecurityGroup, []string) {
+	log := svc1log.FromContext(ctx)
+	var errors []string
 
-	// Convert IP Permissions (combining Ingress and Egress)
-	var fernPermissions []*fernsecuritygroup.IpPermission
-
-	// Add Ingress permissions
-	if awsSG.IpPermissions != nil {
-		for _, perm := range awsSG.IpPermissions {
-			fernPerm := &fernsecuritygroup.IpPermission{
-				Direction:  fernsecuritygroup.PermissionDirectionIngress,
-				IpProtocol: perm.IpProtocol,
-			}
-			if perm.FromPort != nil {
-				fromPort := int(*perm.FromPort)
-				fernPerm.FromPort = &fromPort
-			}
-			if perm.ToPort != nil {
-				toPort := int(*perm.ToPort)
-				fernPerm.ToPort = &toPort
-			}
-			fernPermissions = append(fernPermissions, fernPerm)
+	// Fetch detailed security group rules to get rule IDs
+	var detailedRules []ec2types.SecurityGroupRule
+	if awsSG.GroupId != nil {
+		cfg.Region = region
+		rules, err := fetchSecurityGroupRules(ctx, cfg, *awsSG.GroupId)
+		if err != nil {
+			log.Warn("Failed to fetch detailed security group rules",
+				svc1log.SafeParam("groupId", *awsSG.GroupId),
+				svc1log.SafeParam("region", region),
+				svc1log.Stacktrace(err))
+		} else {
+			detailedRules = rules
 		}
 	}
 
-	// Add Egress permissions
-	if awsSG.IpPermissionsEgress != nil {
-		for _, perm := range awsSG.IpPermissionsEgress {
-			fernPerm := &fernsecuritygroup.IpPermission{
-				Direction:  fernsecuritygroup.PermissionDirectionEgress,
-				IpProtocol: perm.IpProtocol,
-			}
-			if perm.FromPort != nil {
-				fromPort := int(*perm.FromPort)
-				fernPerm.FromPort = &fromPort
-			}
-			if perm.ToPort != nil {
-				toPort := int(*perm.ToPort)
-				fernPerm.ToPort = &toPort
-			}
-			fernPermissions = append(fernPermissions, fernPerm)
+	// Convert SecurityGroupRules directly to fernsecuritygroup.IpPermission
+	var fernPermissions []*fernsecuritygroup.IpPermission
+	for _, rule := range detailedRules {
+		if rule.SecurityGroupRuleId == nil {
+			log.Warn("SecurityGroupRule missing ID", svc1log.SafeParam("rule", rule))
+			continue
 		}
+
+		// Determine direction
+		var direction fernsecuritygroup.PermissionDirection
+		if rule.IsEgress != nil && *rule.IsEgress {
+			direction = fernsecuritygroup.PermissionDirectionEgress
+		} else {
+			direction = fernsecuritygroup.PermissionDirectionIngress
+		}
+
+		fernPerm := &fernsecuritygroup.IpPermission{
+			Id:         *rule.SecurityGroupRuleId,
+			Direction:  direction,
+			IpProtocol: rule.IpProtocol,
+		}
+
+		// Convert ports from int32 to int
+		if rule.FromPort != nil {
+			fromPort := int(*rule.FromPort)
+			fernPerm.FromPort = &fromPort
+		}
+		if rule.ToPort != nil {
+			toPort := int(*rule.ToPort)
+			fernPerm.ToPort = &toPort
+		}
+
+		// Extract description
+		if rule.Description != nil {
+			fernPerm.Description = rule.Description
+		}
+
+		// Extract CIDR blocks - combine IPv4 and IPv6 into single list
+		var cidrs []string
+		if rule.CidrIpv4 != nil {
+			cidrs = append(cidrs, *rule.CidrIpv4)
+		}
+		if rule.CidrIpv6 != nil {
+			cidrs = append(cidrs, *rule.CidrIpv6)
+		}
+		if len(cidrs) > 0 {
+			fernPerm.Cidrs = cidrs
+		}
+
+		fernPermissions = append(fernPermissions, fernPerm)
 	}
 
 	// Convert Tags
@@ -247,7 +303,7 @@ func convertAWSEC2SecurityGroupToFern(awsSG ec2types.SecurityGroup, region strin
 		fernSG.Resources = resourceInfo
 	}
 
-	return fernSG
+	return fernSG, errors
 }
 
 // convertAWSRDSSecurityGroupToFern converts an AWS SDK RDS DB SecurityGroup to a Fern SecurityGroup

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -208,7 +208,7 @@ func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG
 	}
 
 	// Convert SecurityGroupRules directly to fernsecuritygroup.IpPermission
-	var fernPermissions []*fernsecuritygroup.IpPermission
+	var fernPermissions []*fernsecuritygroup.RuleDetails
 	for _, rule := range detailedRules {
 		if rule.SecurityGroupRuleId == nil {
 			log.Warn("SecurityGroupRule missing ID", svc1log.SafeParam("rule", rule))
@@ -223,10 +223,11 @@ func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG
 			direction = fernsecuritygroup.PermissionDirectionIngress
 		}
 
-		fernPerm := &fernsecuritygroup.IpPermission{
+		fernPerm := &fernsecuritygroup.RuleDetails{
 			Id:         *rule.SecurityGroupRuleId,
 			Direction:  direction,
 			IpProtocol: rule.IpProtocol,
+			Peer:       &fernsecuritygroup.RulePeerInfo{},
 		}
 
 		// Convert ports from int32 to int
@@ -253,15 +254,21 @@ func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG
 			cidrs = append(cidrs, *rule.CidrIpv6)
 		}
 		if len(cidrs) > 0 {
-			fernPerm.Cidrs = cidrs
+			fernPerm.Peer.Cidrs = cidrs
 		}
 
 		// Extract referenced security group (missing bidirectional connection!)
 		if rule.ReferencedGroupInfo != nil {
-			fernPerm.ReferencedSecurityGroup = &fernsecuritygroup.ReferencedSecurityGroup{
+			fernPerm.Peer.ReferencedSecurityGroup = &fernsecuritygroup.ReferencedSecurityGroup{
 				GroupId: *rule.ReferencedGroupInfo.GroupId,
 				UserId:  *rule.ReferencedGroupInfo.UserId,
 			}
+		}
+
+		if len(cidrs) == 0 && fernPerm.Peer.ReferencedSecurityGroup == nil {
+			log.Warn("SecurityGroupRule missing CIDR or referenced security group", svc1log.SafeParam("rule", fernPerm))
+			errors = append(errors, fmt.Sprintf("SecurityGroupRule missing CIDR or referenced security group: %v", fernPerm))
+			continue
 		}
 
 		fernPermissions = append(fernPermissions, fernPerm)

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -17,14 +17,14 @@ import (
 )
 
 // fetchSecurityGroupRules retrieves detailed rules for a specific security group
-func fetchSecurityGroupRules(ctx context.Context, cfg aws.Config, groupId string) ([]ec2types.SecurityGroupRule, error) {
+func fetchSecurityGroupRules(ctx context.Context, cfg aws.Config, groupID string) ([]ec2types.SecurityGroupRule, error) {
 	svc := ec2.NewFromConfig(cfg)
 
 	input := &ec2.DescribeSecurityGroupRulesInput{
 		Filters: []ec2types.Filter{
 			{
 				Name:   aws.String("group-id"),
-				Values: []string{groupId},
+				Values: []string{groupID},
 			},
 		},
 	}
@@ -254,6 +254,14 @@ func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG
 		}
 		if len(cidrs) > 0 {
 			fernPerm.Cidrs = cidrs
+		}
+
+		// Extract referenced security group (missing bidirectional connection!)
+		if rule.ReferencedGroupInfo != nil {
+			fernPerm.ReferencedSecurityGroup = &fernsecuritygroup.ReferencedSecurityGroup{
+				GroupId: *rule.ReferencedGroupInfo.GroupId,
+				UserId:  *rule.ReferencedGroupInfo.UserId,
+			}
 		}
 
 		fernPermissions = append(fernPermissions, fernPerm)

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -244,7 +244,7 @@ func convertAWSEC2SecurityGroupToFern(awsSG ec2types.SecurityGroup, region strin
 			Vpc:   vpcInstance,
 			Rules: fernPermissions,
 		}
-		fernSG.Resources = []*fernsecuritygroup.SecurityGroupResourceInfo{resourceInfo}
+		fernSG.Resources = resourceInfo
 	}
 
 	return fernSG
@@ -281,7 +281,7 @@ func convertAWSRDSSecurityGroupToFern(awsSG rdstypes.DBSecurityGroup, region str
 			Vpc:   vpcInstance,
 			Rules: nil, // RDS DB security group rules are not mapped in the unified schema
 		}
-		fernSG.Resources = []*fernsecuritygroup.SecurityGroupResourceInfo{resourceInfo}
+		fernSG.Resources = resourceInfo
 	}
 
 	// Note: EC2SecurityGroups and IPRanges are not included in the Fern SecurityGroup definition


### PR DESCRIPTION
### TL;DR

Changed `SecurityGroup.resources` from a list to a single object in the API definition and implementation.

### What changed?

- Modified the `SecurityGroup` type in `fern/definition/securitygroup/enumerate.yml` to change the `resources` field from `optional<list<SecurityGroupResourceInfo>>` to `optional<SecurityGroupResourceInfo>`
- Updated the corresponding implementation in `internal/securitygroup/enumerate.go` to assign a single resource object instead of a list containing one object in both AWS EC2 and RDS security group conversion functions

### How to test?

- Verify that API clients can properly handle a single `SecurityGroupResourceInfo` object instead of a list
- Test the security group enumeration functionality for both EC2 and RDS security groups to ensure they return the expected data structure
- Check that any code consuming this API is updated to handle the new structure

### Why make this change?

This change simplifies the API by removing an unnecessary list wrapper around the resource information. Since each security group appears to have at most one resource associated with it, representing this as a single optional object rather than a list of objects is more appropriate and leads to a cleaner API design.