### PR TITLE
Update API Gateway Fern

### DIFF
--- a/fern/definition/apigateway/enumerate.yml
+++ b/fern/definition/apigateway/enumerate.yml
@@ -134,7 +134,7 @@ types:
       throttle: optional<Throttle>
   RouteResourceInfo:
     properties:
-      integration: Integration
+      integration: optional<Integration>
       executionRole: optional<common.IamRoleReference>
       cloudWatchLog: optional<common.CloudWatchLogReference>
   Route:

--- a/internal/apigateway/enumerate/apigwv1.go
+++ b/internal/apigateway/enumerate/apigwv1.go
@@ -227,15 +227,18 @@ func getRestAPIRoutes(ctx context.Context, client *apigateway.Client, apiID, reg
 			// Create route-specific resource links
 			resourceLinks := createRouteResources(integration, region)
 
-			// Create resources with integration and other links
-			resources := &apigatewayfern.RouteResourceInfo{
-				Integration: integration,
-			}
+			// Create resources only if there's something to include
+			var resources *apigatewayfern.RouteResourceInfo
+			if integration != nil || (resourceLinks != nil && (resourceLinks.ExecutionRole != nil || resourceLinks.CloudWatchLog != nil)) {
+				resources = &apigatewayfern.RouteResourceInfo{
+					Integration: integration,
+				}
 
-			// Add other resource links if they exist
-			if resourceLinks != nil {
-				resources.ExecutionRole = resourceLinks.ExecutionRole
-				resources.CloudWatchLog = resourceLinks.CloudWatchLog
+				// Add other resource links if they exist
+				if resourceLinks != nil {
+					resources.ExecutionRole = resourceLinks.ExecutionRole
+					resources.CloudWatchLog = resourceLinks.CloudWatchLog
+				}
 			}
 
 			route := &apigatewayfern.Route{

--- a/internal/apigateway/enumerate/apigwv1.go
+++ b/internal/apigateway/enumerate/apigwv1.go
@@ -230,8 +230,11 @@ func getRestAPIRoutes(ctx context.Context, client *apigateway.Client, apiID, reg
 			// Create resources only if there's something to include
 			var resources *apigatewayfern.RouteResourceInfo
 			if integration != nil || (resourceLinks != nil && (resourceLinks.ExecutionRole != nil || resourceLinks.CloudWatchLog != nil)) {
-				resources = &apigatewayfern.RouteResourceInfo{
-					Integration: integration,
+				resources = &apigatewayfern.RouteResourceInfo{}
+
+				// Add integration if it exists
+				if integration != nil {
+					resources.Integration = integration
 				}
 
 				// Add other resource links if they exist
@@ -250,7 +253,10 @@ func getRestAPIRoutes(ctx context.Context, client *apigateway.Client, apiID, reg
 					Authorization:  authType,
 					ApiKeyRequired: method.ApiKeyRequired,
 				},
-				Resources: resources,
+			}
+			// Add resources if they exist
+			if resources != nil && (resources.Integration != nil || resources.ExecutionRole != nil || resources.CloudWatchLog != nil) {
+				route.Resources = resources
 			}
 			routes = append(routes, route)
 		}

--- a/internal/apigateway/enumerate/apigwv2.go
+++ b/internal/apigateway/enumerate/apigwv2.go
@@ -264,15 +264,18 @@ func getHTTPAPIRoutes(ctx context.Context, client *apigatewayv2.Client, apiID, r
 		// Create route-specific resource links
 		resourceLinks := createRouteResources(integration, region)
 
-		// Create resources with integration and other links
-		resources := &apigatewayfern.RouteResourceInfo{
-			Integration: integration,
-		}
+		// Create resources only if there's something to include
+		var resources *apigatewayfern.RouteResourceInfo
+		if integration != nil || (resourceLinks != nil && (resourceLinks.ExecutionRole != nil || resourceLinks.CloudWatchLog != nil)) {
+			resources = &apigatewayfern.RouteResourceInfo{
+				Integration: integration,
+			}
 
-		// Add other resource links if they exist
-		if resourceLinks != nil {
-			resources.ExecutionRole = resourceLinks.ExecutionRole
-			resources.CloudWatchLog = resourceLinks.CloudWatchLog
+			// Add other resource links if they exist
+			if resourceLinks != nil {
+				resources.ExecutionRole = resourceLinks.ExecutionRole
+				resources.CloudWatchLog = resourceLinks.CloudWatchLog
+			}
 		}
 
 		fernRoute := &apigatewayfern.Route{

--- a/internal/apigateway/enumerate/apigwv2.go
+++ b/internal/apigateway/enumerate/apigwv2.go
@@ -267,8 +267,11 @@ func getHTTPAPIRoutes(ctx context.Context, client *apigatewayv2.Client, apiID, r
 		// Create resources only if there's something to include
 		var resources *apigatewayfern.RouteResourceInfo
 		if integration != nil || (resourceLinks != nil && (resourceLinks.ExecutionRole != nil || resourceLinks.CloudWatchLog != nil)) {
-			resources = &apigatewayfern.RouteResourceInfo{
-				Integration: integration,
+			resources = &apigatewayfern.RouteResourceInfo{}
+
+			// Add integration if it exists
+			if integration != nil {
+				resources.Integration = integration
 			}
 
 			// Add other resource links if they exist
@@ -287,7 +290,10 @@ func getHTTPAPIRoutes(ctx context.Context, client *apigatewayv2.Client, apiID, r
 				Authorization: authType,
 				// Note: HTTP API doesn't have API key requirement per route like REST API
 			},
-			Resources: resources,
+		}
+		// Add resources if they exist
+		if resources != nil && (resources.Integration != nil || resources.ExecutionRole != nil || resources.CloudWatchLog != nil) {
+			fernRoute.Resources = resources
 		}
 
 		routes = append(routes, fernRoute)


### PR DESCRIPTION
### TL;DR

Made the `integration` field optional in the `RouteResourceInfo` type.

### What changed?

Updated the `RouteResourceInfo` type in `fern/definition/apigateway/enumerate.yml` to make the `integration` property optional by changing it from `integration: Integration` to `integration: optional<Integration>`.

### How to test?

1. Verify that API Gateway routes can be created without specifying an integration
2. Ensure existing code that relies on the `integration` field handles the optional case properly
3. Validate that the generated API clients correctly reflect this change