### PR TITLE
Split Linux build workflow into separate ARM64 and AMD64 jobs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -16,15 +16,13 @@ env:
   GO_VERSION: "1.24"
 
 jobs:
-  prepare-linux:
-    name: Prepare Linux
-    runs-on: ubuntu-latest
+  # Build ARM64 using native GitHub ARM runner but inside Docker for Alpine compatibility
+  prepare-linux-arm64:
+    name: Prepare Linux ARM64
+    runs-on: ubuntu-22.04-arm
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -48,25 +46,77 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
 
+      # Build ARM64 builder image natively (no QEMU needed)
       - name: Build ARM64 Builder Image
-        shell: bash
         run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
 
+      # Build inside the Alpine container to ensure library compatibility
+      - name: Build ARM64 Binary in Alpine Container
+        run: |
+          docker run \
+            -v $PWD:/app/methodaws \
+            -e GOARCH=arm64 \
+            -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm armbuilder \
+            goreleaser build --single-target --clean --snapshot --timeout 60m \
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-dist
+          path: dist/
+          retention-days: 7
+
+  # Build AMD64 using standard runner (fast, no emulation needed)
+  prepare-linux-amd64:
+    name: Prepare Linux AMD64
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Generate Fern Go Code
+        run: |
+          npm install -g fern-api
+          fern generate --group local
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+
       - name: Build AMD64 Builder Image
-        shell: bash
         run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
 
-      - name: Build ARM64 Image
-        shell: bash
-        run: docker run -v .:/app/methodaws -e GOARCH=arm64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm armbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
-
-      - name: Build AMD64 Image
-        shell: bash
-        run: docker run -v .:/app/methodaws -e GOARCH=amd64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm amdbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
+      # Build inside the Alpine container to ensure library compatibility
+      - name: Build AMD64 Binary in Alpine Container
+        run: |
+          docker run \
+            -v $PWD:/app/methodaws \
+            -e GOARCH=amd64 \
+            -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm amdbuilder \
+            goreleaser build --single-target --clean --snapshot --timeout 60m \
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-dist
+          name: linux-amd64-dist
           path: dist/
           retention-days: 7
 
@@ -142,7 +192,8 @@ jobs:
     name: Build
     needs:
       - prepare
-      - prepare-linux
+      - prepare-linux-arm64
+      - prepare-linux-amd64
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -221,10 +272,12 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
-          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          # Handle both possible build ID naming patterns
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/ 2>/dev/null || \
+             mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/ 2>/dev/null || true
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/ 2>/dev/null || \
+             mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/ 2>/dev/null || true
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -6,7 +6,7 @@ version: 2
 project_name: methodaws
 
 builds:
-  - id: build-linux
+  - id: build-linux-amd64
     main: .
     binary: methodaws
     ldflags:
@@ -18,8 +18,22 @@ builds:
     goos:
       - linux
     goarch:
-      - arm64
       - amd64
+    goarm:
+      - "7"
+  - id: build-linux-arm64
+    main: .
+    binary: methodaws
+    ldflags:
+      - -s -w
+      - "-extldflags '-static -lm -ldl -lpthread'"
+      - -X github.com/method-security/methodaws/main.version={{.Version}}
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - arm64
     goarm:
       - "7"
   - id: build-macos

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -22,9 +22,13 @@ RUN \
 
 FROM base AS arm64
 ARG CLI_NAME
+ARG GORELEASER_VERSION
 RUN \
   wget https://github.com/goreleaser/goreleaser-pro/releases/download/${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_arm64.tar.gz && \
   tar -xvzf goreleaser-pro_Linux_arm64.tar.gz && \
   mv goreleaser /usr/local/bin/goreleaser && \
   rm -rf goreleaser-pro_Linux_arm64.tar.gz LICENSE.md README.md completions manpages
 
+# Final stage that selects the correct architecture
+FROM ${TARGETARCH}
+ARG CLI_NAME

--- a/scripts/upload-release-to-s3.sh
+++ b/scripts/upload-release-to-s3.sh
@@ -100,7 +100,6 @@ find s3_content/ -type f -exec ls -la {} \;
 # Upload to S3 if S3_BUCKET_URL is set
 if [ -n "$S3_BUCKET_URL" ]; then
     echo "=== Uploading to S3 ==="
-    echo "Uploading to S3 bucket: $S3_BUCKET_URL"
 
     # Upload to version-specific path with SHA256 checksums
     aws s3 sync "s3_content/$REPO_NAME/$VERSION_CLEAN/" "$S3_BUCKET_URL/$REPO_NAME/$VERSION_CLEAN/" --checksum-algorithm SHA256


### PR DESCRIPTION
Based on https://github.com/method-security/networkscan/pull/148. The linux CLIs weren't being discovered properly by the S3 uploader; could modify the script for this repo, but presumably we want it to match the others where we split out ARM64 and AMD64 for faster builds.