### PR TITLE
Update Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,48 @@ methodaws <resource> enumerate --regions <AWS Region>
 #### Examples
 
 ```bash
+# Enumerate S3 buckets in a specific region
 methodaws s3 enumerate --regions us-east-1
-```
 
-```bash
+# Enumerate EC2 instances in a specific region
 methodaws ec2 enumerate --regions us-east-1
-```
 
-```bash
+# Enumerate API Gateway resources in multiple regions
 methodaws api-gateway enumerate --regions us-east-1 --regions us-west-2
+
+# Enumerate Lambda functions in all regions (default)
+methodaws lambda enumerate
+
+# Get current AWS caller identity
+methodaws sts arn --regions us-east-1
+
+# Generate EKS credentials for a cluster
+methodaws eks creds --regions us-east-1 --name my-cluster
+
+# List objects in a specific S3 bucket
+methodaws s3 list --regions us-east-1 --name my-bucket
 ```
 
-```bash
-methodaws lambda enumerate
-```
+### Available Resources and Commands
+
+methodaws supports enumeration and management of the following AWS resources:
+
+| Resource | Commands | Description |
+|----------|----------|-------------|
+| **api-gateway** (alias: `agw`) | `enumerate` | API Gateway REST and HTTP APIs |
+| **cloudfront** | `enumerate` | CloudFront distributions |
+| **ec2** | `enumerate` | EC2 instances |
+| **eks** | `enumerate`, `creds` | EKS clusters and Kubernetes credentials |
+| **iam** | `enumerate` | IAM users, roles, and policies |
+| **lambda** | `enumerate` | Lambda functions |
+| **load-balancer** | `enumerate` | Application and Network Load Balancers |
+| **rds** | `enumerate` | RDS database instances |
+| **route53** | `enumerate` | Route53 DNS records |
+| **s3** | `enumerate`, `list`, `external` | S3 buckets and objects |
+| **security-group** | `enumerate` | EC2 security groups |
+| **sts** | `arn` | AWS Security Token Service |
+| **vpc** | `enumerate` | Virtual Private Clouds |
+| **waf** | `enumerate` | Web Application Firewalls |
 
 ## Contributing
 

--- a/docs/docs/eks.md
+++ b/docs/docs/eks.md
@@ -1,16 +1,15 @@
 # EKS
 
-The `methodaws eks` family of commands provide information about an account's EKS clusters.
+The `methodaws eks` family of commands provide information about an account's EKS clusters and Kubernetes credentials.
 
 ## Enumerate
 
-The enumerate command will gather information about all of the EKS clsuters that the provided credentials have access to.
+The enumerate command will gather information about all of the EKS clusters that the provided credentials have access to.
 
 ### Usage
 
 ```bash
 methodaws eks enumerate --regions us-east-1 --output json
-
 ```
 
 ### Help Text
@@ -26,9 +25,40 @@ Flags:
   -h, --help   help for enumerate
 
 Global Flags:
-  -o, --output string          Output format (signal, json). Default value is signal (default "signal")
-  -f, --output-file string     Path to output file. If blank, will output to STDOUT
-  -q, --quiet                  Suppress output
-  -r, --regions stringArray    AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
-  -v, --verbose                Verbose output
+  -o, --output string         Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string    Path to output file. If blank, will output to STDOUT
+  -q, --quiet                 Suppress output
+  -r, --regions stringArray   AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
+  -v, --verbose               Verbose output
+```
+
+## Creds
+
+The creds command generates Kubernetes credentials for an EKS cluster, allowing you to connect to and manage the cluster with kubectl or other Kubernetes tools.
+
+### Usage
+
+```bash
+methodaws eks creds --regions us-east-1 --name <cluster-name> --output json
+```
+
+### Help Text
+
+```bash
+$ methodaws eks creds -h
+Generate a K8s Credential for an EKS instance
+
+Usage:
+  methodaws eks creds [flags]
+
+Flags:
+  -h, --help          help for creds
+      --name string   Name of the EKS cluster
+
+Global Flags:
+  -o, --output string         Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string    Path to output file. If blank, will output to STDOUT
+  -q, --quiet                 Suppress output
+  -r, --regions stringArray   AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
+  -v, --verbose               Verbose output
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -25,7 +25,7 @@ methodaws has several top level flags that can be used on any subcommand. These 
 ```bash
 Flags:
   -h, --help                   help for methodaws
-  -o, --output string          Output format (signal, json). Default value is signal (default "signal")
+  -o, --output string          Output format (signal, json, yaml). Default value is signal (default "signal")
   -f, --output-file string     Path to output file. If blank, will output to STDOUT
   -q, --quiet                  Suppress output
   -r, --regions stringArray    AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.

--- a/docs/docs/s3.md
+++ b/docs/docs/s3.md
@@ -25,69 +25,69 @@ Flags:
   -h, --help   help for enumerate
 
 Global Flags:
-  -o, --output string          Output format (signal, json). Default value is signal (default "signal")
-  -f, --output-file string     Path to output file. If blank, will output to STDOUT
-  -q, --quiet                  Suppress output
-  -r, --regions stringArray    AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
-  -v, --verbose                Verbose output
+  -o, --output string         Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string    Path to output file. If blank, will output to STDOUT
+  -q, --quiet                 Suppress output
+  -r, --regions stringArray   AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
+  -v, --verbose               Verbose output
 ```
 
-## ls
+## list
 
 ### Usage
 
 ```bash
-methodaws s3 ls --regions us-east-1 --output json --name <bucket name>
+methodaws s3 list --regions us-east-1 --output json --name <bucket name>
 ```
 
 ### Help Text
 
 ```bash
-$ methodaws s3 ls -h
+$ methodaws s3 list -h
 List all objects in a single S3 bucket.
 
 Usage:
-  methodaws s3 ls [flags]
+  methodaws s3 list [flags]
 
 Flags:
-  -h, --help          help for ls
+  -h, --help          help for list
       --name string   Name of the S3 bucket
 
 Global Flags:
-  -o, --output string          Output format (signal, json). Default value is signal (default "signal")
-  -f, --output-file string     Path to output file. If blank, will output to STDOUT
-  -q, --quiet                  Suppress output
-  -r, --regions stringArray    AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
-  -v, --verbose                Verbose output
+  -o, --output string         Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string    Path to output file. If blank, will output to STDOUT
+  -q, --quiet                 Suppress output
+  -r, --regions stringArray   AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
+  -v, --verbose               Verbose output
 ```
 
-## externalenumerate
+## external
 
-The externalenumerate command attempts to enumearte a public facing S3 bucket with anonymous credentials.
+The external command attempts to enumerate a public facing S3 bucket with anonymous credentials from an external perspective.
 
 ### Usage
 
 ```bash
-methodaws s3 externalenumerate --regions us-east-1 --name bucketname --output json
+methodaws s3 external --regions us-east-1 --name bucketname --output json
 ```
 
 ### Help Text
 
 ```bash
-$ methodaws s3 externalenumerate -h
-Enumerate a single public facing S3 bucket with no credentials.
+$ methodaws s3 external -h
+Enumerate a single public facing S3 bucket from an external prespective.
 
 Usage:
-  methodaws s3 externalenumerate [flags]
+  methodaws s3 external [flags]
 
 Flags:
-  -h, --help          help for externalenumerate
+  -h, --help          help for external
       --name string   Name of the S3 bucket
 
 Global Flags:
-  -o, --output string          Output format (signal, json). Default value is signal (default "signal")
-  -f, --output-file string     Path to output file. If blank, will output to STDOUT
-  -q, --quiet                  Suppress output
-  -r, --regions stringArray    AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
-  -v, --verbose                Verbose output
+  -o, --output string         Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string    Path to output file. If blank, will output to STDOUT
+  -q, --quiet                 Suppress output
+  -r, --regions stringArray   AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.
+  -v, --verbose               Verbose output
 ```


### PR DESCRIPTION
# Enhanced Documentation for MethodAWS CLI Tool

### TL;DR

Improved documentation for the MethodAWS CLI tool, adding a comprehensive resource table, new command examples, and updating command names for consistency.

### What changed?

- Added a comprehensive resource table in [README.md](http://README.md) showing all supported AWS resources and their available commands
- Expanded the examples section with more use cases including STS, EKS, and S3 operations
- Added documentation for the EKS `creds` command that generates Kubernetes credentials
- Renamed S3 commands for better consistency:
    - `ls` → `list`
    - `externalenumerate` → `external`
- Updated output format options to include YAML alongside JSON and signal formats
- Fixed typos and improved command descriptions throughout the documentation