### PR TITLE
Add IAM Default Role Flag to IAM Enumerate

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -27,8 +27,14 @@ func (a *MethodAws) InitIamCommand() {
 				return
 			}
 
+			excludeDefaultRoles, err := cmd.Flags().GetBool("exclude-default-roles")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Get Config
-			config := getIamEnumerateConfig(a.RootFlags.Regions, accountID)
+			config := getIamEnumerateConfig(accountID, excludeDefaultRoles)
 
 			// Get Report
 			report := iamInternal.EnumerateIam(cmd.Context(), *a.AwsConfig, config)
@@ -36,13 +42,16 @@ func (a *MethodAws) InitIamCommand() {
 		},
 	}
 
+	enumerateCmd.Flags().Bool("exclude-default-roles", false, "Exclude default roles")
+
 	iamCmd.AddCommand(enumerateCmd)
 	a.RootCmd.AddCommand(iamCmd)
 }
 
 // getIamEnumerateConfig returns an IamEnumerateConfig with the given regions and account ID
-func getIamEnumerateConfig(regions []string, accountID string) iam.IamEnumerateConfig {
+func getIamEnumerateConfig(accountID string, excludeDefaultRoles bool) iam.IamEnumerateConfig {
 	return iam.IamEnumerateConfig{
-		AccountId: accountID,
+		AccountId:           accountID,
+		ExcludeDefaultRoles: excludeDefaultRoles,
 	}
 }

--- a/fern/definition/iam/enumerate.yml
+++ b/fern/definition/iam/enumerate.yml
@@ -6,6 +6,7 @@ types:
   IamEnumerateConfig:
     properties:
       accountId: string
+      excludeDefaultRoles: boolean
 # Supporting Structs
   RoleLastUsed:
     properties:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.20.0"
+  "version": "3.47.1"
 }

--- a/internal/iam/enumerate/enumerate.go
+++ b/internal/iam/enumerate/enumerate.go
@@ -24,7 +24,7 @@ func EnumerateIam(ctx context.Context, awsConfig aws.Config, config iam.IamEnume
 
 	// Enumerate roles (with nested policy information)
 	log.Info("Enumerating IAM roles with attached policies")
-	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig)
+	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig, config.ExcludeDefaultRoles)
 	if len(rolesErrors) > 0 {
 		log.Warn("Errors encountered during role enumeration",
 			svc1log.SafeParam("errorCount", len(rolesErrors)))

--- a/internal/iam/enumerate/roles.go
+++ b/internal/iam/enumerate/roles.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	common "github.com/Method-Security/methodaws/generated/go/common"
 	iam "github.com/Method-Security/methodaws/generated/go/iam"
@@ -16,7 +17,7 @@ import (
 )
 
 // enumerateIamRoles retrieves all IAM roles with their attached policies
-func enumerateIamRoles(ctx context.Context, cfg aws.Config) ([]*iam.IamRoles, []string) {
+func enumerateIamRoles(ctx context.Context, cfg aws.Config, excludeDefaultRoles bool) ([]*iam.IamRoles, []string) {
 	log := svc1log.FromContext(ctx)
 	client := iamaws.NewFromConfig(cfg)
 	var iamRoles []*iam.IamRoles
@@ -30,6 +31,19 @@ func enumerateIamRoles(ctx context.Context, cfg aws.Config) ([]*iam.IamRoles, []
 	}
 
 	log.Info("Processing IAM roles", svc1log.SafeParam("roleCount", len(roles)))
+
+	// Filter out default roles if requested
+	if excludeDefaultRoles {
+		filteredRoles := make([]types.Role, 0, len(roles))
+		for _, role := range roles {
+			if !isDefaultAwsRole(role) {
+				filteredRoles = append(filteredRoles, role)
+			}
+		}
+		roles = filteredRoles
+		log.Info("Filtered default roles",
+			svc1log.SafeParam("remainingRoleCount", len(roles)))
+	}
 
 	for _, role := range roles {
 		if role.Arn == nil {
@@ -293,4 +307,54 @@ func discoverEc2ReferencesFromPolicies(policies []*iam.AttachedPolicy) []*common
 		ec2Instances = append(ec2Instances, instance)
 	}
 	return ec2Instances
+}
+
+var serviceLinkedRoleArnRe = regexp.MustCompile(
+	`^arn:aws[a-z-]*:iam::\d{12}:role/aws-service-role/`,
+)
+
+// isServiceLinkedRole returns true if the role is an AWS service-linked role.
+func isServiceLinkedRole(role types.Role) bool {
+	if role.Path != nil && strings.HasPrefix(*role.Path, "/aws-service-role/") {
+		return true
+	}
+
+	// Fallback if Path is missing
+	if role.Arn != nil && serviceLinkedRoleArnRe.MatchString(*role.Arn) {
+		return true
+	}
+
+	return false
+}
+
+// isIdentityCenterRole returns true if the role was created by IAM Identity Center (SSO).
+func isIdentityCenterRole(role types.Role) bool {
+	// Identity Center roles always start with AWSReservedSSO_
+	if role.RoleName != nil && strings.HasPrefix(*role.RoleName, "AWSReservedSSO_") {
+		return true
+	}
+
+	// Extra safety: path used by SSO-managed roles
+	if role.Path != nil && strings.Contains(*role.Path, "/aws-reserved/sso.amazonaws.com/") {
+		return true
+	}
+
+	return false
+}
+
+// isControlTowerRole returns true if the role is created/required by AWS Control Tower.
+func isControlTowerRole(role types.Role) bool {
+	return role.RoleName != nil && *role.RoleName == "AWSControlTowerExecution"
+}
+
+// isDefaultAwsRole returns true if the role is AWS-shipped (created and managed by AWS).
+//
+// This includes:
+//   - Service-linked roles
+//   - IAM Identity Center (SSO) roles
+//   - Control Tower roles
+func isDefaultAwsRole(role types.Role) bool {
+	return isServiceLinkedRole(role) ||
+		isIdentityCenterRole(role) ||
+		isControlTowerRole(role)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces optional filtering of AWS-managed IAM roles during enumeration.
> 
> - Adds `--exclude-default-roles` flag to `iam enumerate` and threads `ExcludeDefaultRoles` through `IamEnumerateConfig`
> - Updates API schema (`fern/definition/iam/enumerate.yml`) and bumps Fern config version
> - Extends role enumeration to accept the flag and filter out default roles via `isDefaultAwsRole` (service-linked, Identity Center, Control Tower) with supporting helpers and regex
> - Adjusts logging and report wiring to reflect filtered role counts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6708bdb5dcc2100f8f2e2efa2b669aed8b63ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->