### PR TITLE
Bump Fern

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -62,6 +62,7 @@ jobs:
             --rm armbuilder \
             goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -98,6 +99,7 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
 
+      # Build AMD64 builder image natively (no QEMU needed)
       - name: Build AMD64 Builder Image
         run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
 
@@ -198,15 +200,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
-          remove-android: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
-
       - name: Install Dependences
         run: sudo apt install libpcap-dev
 
@@ -295,4 +288,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true" 
+          COSIGN_EXPERIMENTAL: "true"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.47.1"
+  "version": "3.78.1"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   pypi-local:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         output:
           location: local-file-system
           path: ../generated/python
@@ -21,7 +21,7 @@ groups:
   pypi-test:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodaws
         output:
@@ -33,7 +33,7 @@ groups:
   pypi:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodaws
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/config-only changes; risk is limited to potential build/release workflow regressions due to artifact handling and removed disk-space step.
> 
> **Overview**
> Bumps Fern CLI/config version to `3.78.1` and updates the Python generator (`fern-pydantic-model`) from `1.11.1` to `1.11.2`.
> 
> Updates the reusable build workflow to upload `dist/` artifacts for Linux ARM64/AMD64 preparation jobs, removes the build-space maximization step from the final `build` job, and normalizes `COSIGN_EXPERIMENTAL` env formatting for the GoReleaser release step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 400bdcfd61b3485b59ae20f1ed4934627eacff4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->