### PR TITLE
MethodAWS: Clean Up

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -27,14 +27,14 @@ func (a *MethodAws) InitIamCommand() {
 				return
 			}
 
-			excludeDefaultRoles, err := cmd.Flags().GetBool("exclude-default-roles")
+			excludeAWSManagedRoles, err := cmd.Flags().GetBool("exclude-aws-managed-roles")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
 			// Get Config
-			config := getIamEnumerateConfig(accountID, excludeDefaultRoles)
+			config := getIamEnumerateConfig(accountID, excludeAWSManagedRoles)
 
 			// Get Report
 			report := iamInternal.EnumerateIam(cmd.Context(), *a.AwsConfig, config)
@@ -42,16 +42,16 @@ func (a *MethodAws) InitIamCommand() {
 		},
 	}
 
-	enumerateCmd.Flags().Bool("exclude-default-roles", false, "Exclude default roles")
+	enumerateCmd.Flags().Bool("exclude-aws-managed-roles", false, "Exclude AWS managed roles")
 
 	iamCmd.AddCommand(enumerateCmd)
 	a.RootCmd.AddCommand(iamCmd)
 }
 
 // getIamEnumerateConfig returns an IamEnumerateConfig with the given regions and account ID
-func getIamEnumerateConfig(accountID string, excludeDefaultRoles bool) iam.IamEnumerateConfig {
+func getIamEnumerateConfig(accountID string, excludeAWSManagedRoles bool) iam.IamEnumerateConfig {
 	return iam.IamEnumerateConfig{
-		AccountId:           accountID,
-		ExcludeDefaultRoles: excludeDefaultRoles,
+		AccountId:              accountID,
+		ExcludeAwsManagedRoles: excludeAWSManagedRoles,
 	}
 }

--- a/cmd/waf.go
+++ b/cmd/waf.go
@@ -4,8 +4,8 @@ import (
 	// Generated
 	waffern "github.com/Method-Security/methodaws/generated/go/waf"
 	// Internal
-	"github.com/Method-Security/methodaws/internal/sts"
 	"github.com/Method-Security/methodaws/internal/waf"
+	"github.com/Method-Security/methodaws/utils"
 
 	// External
 	"github.com/spf13/cobra"
@@ -28,14 +28,14 @@ func (a *MethodAws) InitWAFCommand() {
 		Long:  `Enumerate WAFs in your AWS account.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get Account ID
-			accountID, err := sts.GetAccountID(cmd.Context(), *a.AwsConfig)
+			accountID, err := utils.GetAccountID(cmd.Context(), *a.AwsConfig)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
 			// Config
-			config := getWafEnumerateConfig(*accountID, a.RootFlags.Regions)
+			config := getWafEnumerateConfig(accountID, a.RootFlags.Regions)
 
 			// Report
 			report := waf.EnumerateWAF(cmd.Context(), *a.AwsConfig, config)

--- a/fern/definition/iam/enumerate.yml
+++ b/fern/definition/iam/enumerate.yml
@@ -20,7 +20,6 @@ types:
   AttachedPolicyConfigurationInfo:
     properties:
       policyDocument: optional<string>
-      isCustomerManaged: optional<boolean>
   AttachedPolicy:
     properties:
       identification: AttachedPolicyIdentificationInfo

--- a/fern/definition/iam/enumerate.yml
+++ b/fern/definition/iam/enumerate.yml
@@ -6,7 +6,7 @@ types:
   IamEnumerateConfig:
     properties:
       accountId: string
-      excludeDefaultRoles: boolean
+      excludeAWSManagedRoles: boolean
 # Supporting Structs
   RoleLastUsed:
     properties:

--- a/internal/apigateway/enumerate/apigwv1.go
+++ b/internal/apigateway/enumerate/apigwv1.go
@@ -197,16 +197,23 @@ func getRestAPIRoutes(ctx context.Context, client *apigateway.Client, apiID, reg
 	var routes []*apigatewayfern.Route
 	var errors []string
 
-	resources, err := client.GetResources(ctx, &apigateway.GetResourcesInput{RestApiId: &apiID})
-	if err != nil {
-		log.Warn("Failed to get resources for API",
-			svc1log.SafeParam("region", region),
-			svc1log.SafeParam("apiId", apiID),
-			svc1log.Stacktrace(err))
-		return routes, []string{fmt.Sprintf("GetResources failed for API %s: %s", apiID, err.Error())}
+	// Paginate through all resources
+	var allResources []types.Resource
+	paginator := apigateway.NewGetResourcesPaginator(client, &apigateway.GetResourcesInput{RestApiId: &apiID})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.Warn("Failed to get resources for API",
+				svc1log.SafeParam("region", region),
+				svc1log.SafeParam("apiId", apiID),
+				svc1log.Stacktrace(err))
+			errors = append(errors, fmt.Sprintf("GetResources failed for API %s: %s", apiID, err.Error()))
+			break
+		}
+		allResources = append(allResources, page.Items...)
 	}
 
-	for _, resource := range resources.Items {
+	for _, resource := range allResources {
 		for methodName := range resource.ResourceMethods {
 			method, err := client.GetMethod(ctx, &apigateway.GetMethodInput{
 				RestApiId:  &apiID,
@@ -457,15 +464,21 @@ func getAPICertificates(ctx context.Context, client *apigateway.Client) ([]*apig
 	var certificates []*apigatewayfern.Certificate
 	var errors []string
 
-	// Get domain names associated with the API
-	domainNames, err := client.GetDomainNames(ctx, &apigateway.GetDomainNamesInput{})
-	if err != nil {
-		log.Warn("Failed to get domain names",
-			svc1log.Stacktrace(err))
-		return certificates, []string{fmt.Sprintf("GetDomainNames failed: %s", err.Error())}
+	// Get domain names associated with the API with pagination
+	var allDomains []types.DomainName
+	domainPaginator := apigateway.NewGetDomainNamesPaginator(client, &apigateway.GetDomainNamesInput{})
+	for domainPaginator.HasMorePages() {
+		page, err := domainPaginator.NextPage(ctx)
+		if err != nil {
+			log.Warn("Failed to get domain names",
+				svc1log.Stacktrace(err))
+			errors = append(errors, fmt.Sprintf("GetDomainNames failed: %s", err.Error()))
+			break
+		}
+		allDomains = append(allDomains, page.Items...)
 	}
 
-	for _, domain := range domainNames.Items {
+	for _, domain := range allDomains {
 		if domain.CertificateArn != nil {
 			cert := &apigatewayfern.Certificate{
 				Arn:        *domain.CertificateArn,
@@ -498,33 +511,37 @@ func getAPIKeysAndUsagePlans(ctx context.Context, client *apigateway.Client, api
 	var usagePlans []string
 	var errors []string
 
-	// Get API keys - filter for those associated with this API
-	keysResult, err := client.GetApiKeys(ctx, &apigateway.GetApiKeysInput{})
-	if err != nil {
-		log.Warn("Failed to get API keys",
-			svc1log.SafeParam("apiId", apiID),
-			svc1log.Stacktrace(err))
-		errors = append(errors, fmt.Sprintf("GetApiKeys failed: %s", err.Error()))
-	} else {
-		for _, key := range keysResult.Items {
+	// Get API keys with pagination
+	keysPaginator := apigateway.NewGetApiKeysPaginator(client, &apigateway.GetApiKeysInput{})
+	for keysPaginator.HasMorePages() {
+		page, err := keysPaginator.NextPage(ctx)
+		if err != nil {
+			log.Warn("Failed to get API keys",
+				svc1log.SafeParam("apiId", apiID),
+				svc1log.Stacktrace(err))
+			errors = append(errors, fmt.Sprintf("GetApiKeys failed: %s", err.Error()))
+			break
+		}
+		for _, key := range page.Items {
 			if key.Id != nil {
-				// Check if this API key is associated with our API by checking usage plans
 				apiKeys = append(apiKeys, *key.Id)
 			}
 		}
 	}
 
-	// Get usage plans associated with this API
-	plansResult, err := client.GetUsagePlans(ctx, &apigateway.GetUsagePlansInput{})
-	if err != nil {
-		log.Warn("Failed to get usage plans",
-			svc1log.SafeParam("apiId", apiID),
-			svc1log.Stacktrace(err))
-		errors = append(errors, fmt.Sprintf("GetUsagePlans failed: %s", err.Error()))
-	} else {
-		for _, plan := range plansResult.Items {
+	// Get usage plans with pagination
+	plansPaginator := apigateway.NewGetUsagePlansPaginator(client, &apigateway.GetUsagePlansInput{})
+	for plansPaginator.HasMorePages() {
+		page, err := plansPaginator.NextPage(ctx)
+		if err != nil {
+			log.Warn("Failed to get usage plans",
+				svc1log.SafeParam("apiId", apiID),
+				svc1log.Stacktrace(err))
+			errors = append(errors, fmt.Sprintf("GetUsagePlans failed: %s", err.Error()))
+			break
+		}
+		for _, plan := range page.Items {
 			if plan.Id != nil && plan.ApiStages != nil {
-				// Check if this usage plan is associated with our API
 				for _, apiStage := range plan.ApiStages {
 					if apiStage.ApiId != nil && *apiStage.ApiId == apiID {
 						usagePlans = append(usagePlans, *plan.Id)

--- a/internal/apigateway/enumerate/apigwv2.go
+++ b/internal/apigateway/enumerate/apigwv2.go
@@ -98,7 +98,7 @@ func convertV2HttpAPIToFern(ctx context.Context, client *apigatewayv2.Client, ap
 	var errors []string
 
 	if api.ApiId == nil {
-		log.Warn("API Gateway API ID is nil", svc1log.SafeParam("apiId", *api.ApiId))
+		log.Warn("API Gateway API ID is nil")
 		errors = append(errors, "api gateway API ID is nil")
 		return nil, errors
 	}
@@ -201,13 +201,26 @@ func getHTTPAPIRoutes(ctx context.Context, client *apigatewayv2.Client, apiID, r
 	var routes []*apigatewayfern.Route
 	var errors []string
 
-	// Get routes for the API
-	routesResult, err := client.GetRoutes(ctx, &apigatewayv2.GetRoutesInput{ApiId: &apiID})
-	if err != nil {
-		return routes, []string{err.Error()}
+	// Get routes for the API with pagination
+	var allRoutes []types.Route
+	var nextToken *string
+	for {
+		routesResult, err := client.GetRoutes(ctx, &apigatewayv2.GetRoutesInput{
+			ApiId:     &apiID,
+			NextToken: nextToken,
+		})
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("GetRoutes failed for API %s: %s", apiID, err.Error()))
+			break
+		}
+		allRoutes = append(allRoutes, routesResult.Items...)
+		if routesResult.NextToken == nil {
+			break
+		}
+		nextToken = routesResult.NextToken
 	}
 
-	for _, route := range routesResult.Items {
+	for _, route := range allRoutes {
 		// Get integration for this route if it exists
 		var integration *apigatewayfern.Integration
 		if route.Target != nil {
@@ -403,13 +416,25 @@ func getHTTPAPICertificates(ctx context.Context, client *apigatewayv2.Client, ap
 	var certificates []*apigatewayfern.Certificate
 	var errors []string
 
-	// Get domain names for this API
-	domainNames, err := client.GetDomainNames(ctx, &apigatewayv2.GetDomainNamesInput{})
-	if err != nil {
-		return certificates, []string{err.Error()}
+	// Get domain names for this API with pagination
+	var allDomains []types.DomainName
+	var domainNextToken *string
+	for {
+		domainResult, err := client.GetDomainNames(ctx, &apigatewayv2.GetDomainNamesInput{
+			NextToken: domainNextToken,
+		})
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("GetDomainNames failed: %s", err.Error()))
+			break
+		}
+		allDomains = append(allDomains, domainResult.Items...)
+		if domainResult.NextToken == nil {
+			break
+		}
+		domainNextToken = domainResult.NextToken
 	}
 
-	for _, domain := range domainNames.Items {
+	for _, domain := range allDomains {
 		// Check if this domain is associated with our API
 		mappings, err := client.GetApiMappings(ctx, &apigatewayv2.GetApiMappingsInput{
 			DomainName: domain.DomainName,
@@ -421,13 +446,18 @@ func getHTTPAPICertificates(ctx context.Context, client *apigatewayv2.Client, ap
 		// Check if any mapping is for our API
 		for _, mapping := range mappings.Items {
 			if mapping.ApiId != nil && *mapping.ApiId == apiID {
+				if len(domain.DomainNameConfigurations) == 0 || domain.DomainNameConfigurations[0].CertificateArn == nil {
+					errors = append(errors, fmt.Sprintf("Domain %s has no certificate configuration", aws.ToString(domain.DomainName)))
+					break
+				}
+
 				cert := &apigatewayfern.Certificate{
 					Arn:        *domain.DomainNameConfigurations[0].CertificateArn,
 					DomainName: domain.DomainName,
 				}
 
 				// Convert security policy
-				if len(domain.DomainNameConfigurations) > 0 && domain.DomainNameConfigurations[0].SecurityPolicy != "" {
+				if domain.DomainNameConfigurations[0].SecurityPolicy != "" {
 					switch domain.DomainNameConfigurations[0].SecurityPolicy {
 					case types.SecurityPolicyTls10:
 						policy := apigatewayfern.SecurityPolicyTls10

--- a/internal/ec2/enumerate/enumerate.go
+++ b/internal/ec2/enumerate/enumerate.go
@@ -75,11 +75,8 @@ func enumerateEc2ForRegion(ctx context.Context, awsConfig aws.Config, region str
 	client := ec2aws.NewFromConfig(regionConfig)
 
 	// Get all instances
-	awsInstances, err := getAllInstances(ctx, client, region)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return instances, errors
-	}
+	awsInstances, errs := getAllInstances(ctx, client, region)
+	errors = append(errors, errs...)
 
 	log.Info("Processing ec2aws instances",
 		svc1log.SafeParam("region", region),
@@ -103,14 +100,16 @@ func enumerateEc2ForRegion(ctx context.Context, awsConfig aws.Config, region str
 }
 
 // getAllInstances retrieves all ec2aws instances in a region
-func getAllInstances(ctx context.Context, client *ec2aws.Client, region string) ([]types.Instance, error) {
+func getAllInstances(ctx context.Context, client *ec2aws.Client, region string) ([]types.Instance, []string) {
 	var instances []types.Instance
+	var errors []string
 
 	paginator := ec2aws.NewDescribeInstancesPaginator(client, &ec2aws.DescribeInstancesInput{})
 	for paginator.HasMorePages() {
 		result, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list instances in region %s: %w", region, err)
+			errors = append(errors, fmt.Sprintf("failed to list instances in region %s: %s", region, err.Error()))
+			break
 		}
 
 		// Extract instances from reservations
@@ -119,7 +118,7 @@ func getAllInstances(ctx context.Context, client *ec2aws.Client, region string) 
 		}
 	}
 
-	return instances, nil
+	return instances, errors
 }
 
 // processInstance converts an AWS instance to Fern format

--- a/internal/eks/enumerate/creds.go
+++ b/internal/eks/enumerate/creds.go
@@ -78,7 +78,10 @@ func CredsEks(ctx context.Context, cfg aws.Config, clusterName string) (*eksfern
 	}
 
 	expiration := tok.Expiration
-	caCert := aws.ToString(clusterOutput.Cluster.CertificateAuthority.Data)
+	var caCert string
+	if clusterOutput.Cluster.CertificateAuthority != nil {
+		caCert = aws.ToString(clusterOutput.Cluster.CertificateAuthority.Data)
+	}
 	encodedToken := base64.StdEncoding.EncodeToString([]byte(tok.Token))
 	credInfo := eksfern.CredentialInfo{
 		Url:        aws.ToString(clusterOutput.Cluster.Endpoint),

--- a/internal/eks/enumerate/enumerate.go
+++ b/internal/eks/enumerate/enumerate.go
@@ -71,15 +71,26 @@ func enumerateEksForRegion(ctx context.Context, cfg aws.Config, region string) (
 	var clusters []*eksfern.EksInstance
 	var errors []string
 
-	// List clusters
-	clusterList, err := eksSvc.ListClusters(ctx, &eks.ListClustersInput{})
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Error listing clusters in region %s: %s", region, err.Error()))
-		return clusters, errors
+	// List clusters with pagination
+	var allClusterNames []string
+	var nextToken *string
+	for {
+		clusterList, err := eksSvc.ListClusters(ctx, &eks.ListClustersInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Error listing clusters in region %s: %s", region, err.Error()))
+			break
+		}
+		allClusterNames = append(allClusterNames, clusterList.Clusters...)
+		if clusterList.NextToken == nil {
+			break
+		}
+		nextToken = clusterList.NextToken
 	}
 
 	// Process each cluster
-	for _, clusterName := range clusterList.Clusters {
+	for _, clusterName := range allClusterNames {
 		cluster, errs := processCluster(ctx, cfg, eksSvc, clusterName, region)
 		if cluster != nil {
 			clusters = append(clusters, cluster)
@@ -164,23 +175,23 @@ func enumerateKubernetesResources(ctx context.Context, cfg aws.Config, cluster *
 		return fernNodes, fernServices, errors
 	}
 
-	// Get raw Kubernetes resources
+	// Get raw Kubernetes resources - collect what we can, don't discard on partial failure
 	podList, err := kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to list pods in cluster %s: %s", *cluster.Name, err.Error()))
-		return fernNodes, fernServices, errors
+		podList = &v1.PodList{}
 	}
 
 	nodeList, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to list nodes in cluster %s: %s", *cluster.Name, err.Error()))
-		return fernNodes, fernServices, errors
+		nodeList = &v1.NodeList{}
 	}
 
 	serviceList, err := kubeClient.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to list services in cluster %s: %s", *cluster.Name, err.Error()))
-		return fernNodes, fernServices, errors
+		serviceList = &v1.ServiceList{}
 	}
 
 	// Build service-pod relationships
@@ -256,6 +267,9 @@ func createKubernetesClient(ctx context.Context, cfg aws.Config, cluster *eksTyp
 	}
 
 	// Decode the certificate authority data
+	if cluster.CertificateAuthority == nil || cluster.CertificateAuthority.Data == nil {
+		return nil, fmt.Errorf("cluster %s has no certificate authority data", *cluster.Name)
+	}
 	caCert, err := base64.StdEncoding.DecodeString(*cluster.CertificateAuthority.Data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode certificate authority data: %w", err)

--- a/internal/iam/enumerate/enumerate.go
+++ b/internal/iam/enumerate/enumerate.go
@@ -24,7 +24,7 @@ func EnumerateIam(ctx context.Context, awsConfig aws.Config, config iam.IamEnume
 
 	// Enumerate roles (with nested policy information)
 	log.Info("Enumerating IAM roles with attached policies")
-	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig, config.ExcludeAWSManagedRoles)
+	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig, config.ExcludeAwsManagedRoles)
 	if len(rolesErrors) > 0 {
 		log.Warn("Errors encountered during role enumeration",
 			svc1log.SafeParam("errorCount", len(rolesErrors)))

--- a/internal/iam/enumerate/enumerate.go
+++ b/internal/iam/enumerate/enumerate.go
@@ -24,7 +24,7 @@ func EnumerateIam(ctx context.Context, awsConfig aws.Config, config iam.IamEnume
 
 	// Enumerate roles (with nested policy information)
 	log.Info("Enumerating IAM roles with attached policies")
-	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig, config.ExcludeDefaultRoles)
+	roles, rolesErrors := enumerateIamRoles(ctx, awsConfig, config.ExcludeAWSManagedRoles)
 	if len(rolesErrors) > 0 {
 		log.Warn("Errors encountered during role enumeration",
 			svc1log.SafeParam("errorCount", len(rolesErrors)))

--- a/internal/iam/enumerate/roles.go
+++ b/internal/iam/enumerate/roles.go
@@ -138,17 +138,9 @@ func getAttachedPoliciesForRole(ctx context.Context, client *iamaws.Client, role
 
 		for _, policy := range result.AttachedPolicies {
 			if policy.PolicyArn != nil && policy.PolicyName != nil {
-				// Determine if it's customer managed (Local scope) or AWS managed
-				isCustomerManaged := !isAWSManagedRole(role)
-				var policyDoc *string
-				// Get policy document if it's customer managed
-				if isCustomerManaged {
-					doc, err := getPolicyDocument(ctx, client, *policy.PolicyArn)
-					if err != nil {
-						errors = append(errors, fmt.Sprintf("failed to get policy document for %s: %v", *policy.PolicyArn, err))
-					} else {
-						policyDoc = doc
-					}
+				policyDoc, err := getPolicyDocument(ctx, client, *policy.PolicyArn)
+				if err != nil {
+					errors = append(errors, fmt.Sprintf("failed to get policy document for %s: %v", *policy.PolicyArn, err))
 				}
 
 				attachedPolicy := &iam.AttachedPolicy{
@@ -157,8 +149,7 @@ func getAttachedPoliciesForRole(ctx context.Context, client *iamaws.Client, role
 						PolicyName: *policy.PolicyName,
 					},
 					Configuration: &iam.AttachedPolicyConfigurationInfo{
-						PolicyDocument:    policyDoc,
-						IsCustomerManaged: &isCustomerManaged,
+						PolicyDocument: policyDoc,
 					},
 				}
 

--- a/internal/iam/enumerate/roles.go
+++ b/internal/iam/enumerate/roles.go
@@ -138,7 +138,7 @@ func getAttachedPoliciesForRole(ctx context.Context, client *iamaws.Client, role
 
 		for _, policy := range result.AttachedPolicies {
 			if policy.PolicyArn != nil && policy.PolicyName != nil {
-			// Determine if it's customer managed (Local scope) or AWS managed
+				// Determine if it's customer managed (Local scope) or AWS managed
 				isCustomerManaged := !isAWSManagedRole(role)
 				var policyDoc *string
 				// Get policy document if it's customer managed

--- a/internal/iam/enumerate/roles.go
+++ b/internal/iam/enumerate/roles.go
@@ -17,26 +17,23 @@ import (
 )
 
 // enumerateIamRoles retrieves all IAM roles with their attached policies
-func enumerateIamRoles(ctx context.Context, cfg aws.Config, excludeDefaultRoles bool) ([]*iam.IamRoles, []string) {
+func enumerateIamRoles(ctx context.Context, cfg aws.Config, excludeAWSManagedRoles bool) ([]*iam.IamRoles, []string) {
 	log := svc1log.FromContext(ctx)
 	client := iamaws.NewFromConfig(cfg)
 	var iamRoles []*iam.IamRoles
 	var errors []string
 
 	// Get all roles
-	roles, err := getAllRoles(ctx, client)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return iamRoles, errors
-	}
+	roles, errs := getAllRoles(ctx, client)
+	errors = append(errors, errs...)
 
 	log.Info("Processing IAM roles", svc1log.SafeParam("roleCount", len(roles)))
 
 	// Filter out default roles if requested
-	if excludeDefaultRoles {
+	if excludeAWSManagedRoles {
 		filteredRoles := make([]types.Role, 0, len(roles))
 		for _, role := range roles {
-			if !isDefaultAwsRole(role) {
+			if !isAWSManagedRole(role) {
 				filteredRoles = append(filteredRoles, role)
 			}
 		}
@@ -67,19 +64,21 @@ func enumerateIamRoles(ctx context.Context, cfg aws.Config, excludeDefaultRoles 
 }
 
 // getAllRoles retrieves all IAM roles
-func getAllRoles(ctx context.Context, client *iamaws.Client) ([]types.Role, error) {
+func getAllRoles(ctx context.Context, client *iamaws.Client) ([]types.Role, []string) {
 	var roles []types.Role
+	var errors []string
 
 	paginator := iamaws.NewListRolesPaginator(client, &iamaws.ListRolesInput{})
 	for paginator.HasMorePages() {
 		result, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list roles: %w", err)
+			errors = append(errors, fmt.Sprintf("failed to list roles: %s", err.Error()))
+			break
 		}
 		roles = append(roles, result.Roles...)
 	}
 
-	return roles, nil
+	return roles, errors
 }
 
 // processRole converts a role and enriches it with policy information
@@ -87,7 +86,7 @@ func processRole(ctx context.Context, client *iamaws.Client, role types.Role) (*
 	var errors []string
 
 	// Get attached policies
-	attachedPolicies, errs := getAttachedPoliciesForRole(ctx, client, *role.RoleName)
+	attachedPolicies, errs := getAttachedPoliciesForRole(ctx, client, role)
 	errors = append(errors, errs...)
 
 	// Convert role last used if present
@@ -121,27 +120,26 @@ func processRole(ctx context.Context, client *iamaws.Client, role types.Role) (*
 }
 
 // getAttachedPoliciesForRole gets all attached policies for a role with their documents
-func getAttachedPoliciesForRole(ctx context.Context, client *iamaws.Client, roleName string) ([]*iam.AttachedPolicy, []string) {
+func getAttachedPoliciesForRole(ctx context.Context, client *iamaws.Client, role types.Role) ([]*iam.AttachedPolicy, []string) {
 	var attachedPolicies []*iam.AttachedPolicy
 	var errors []string
 
 	// List attached policies
 	paginator := iamaws.NewListAttachedRolePoliciesPaginator(client, &iamaws.ListAttachedRolePoliciesInput{
-		RoleName: &roleName,
+		RoleName: role.RoleName,
 	})
 
 	for paginator.HasMorePages() {
 		result, err := paginator.NextPage(ctx)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("failed to list attached policies for role %s: %v", roleName, err))
+			errors = append(errors, fmt.Sprintf("failed to list attached policies for role %s: %v", *role.RoleName, err))
 			break
 		}
 
 		for _, policy := range result.AttachedPolicies {
 			if policy.PolicyArn != nil && policy.PolicyName != nil {
-				// Determine if it's customer managed (Local scope) or AWS managed
-				isCustomerManaged := !isAWSManagedPolicy(*policy.PolicyArn)
-
+			// Determine if it's customer managed (Local scope) or AWS managed
+				isCustomerManaged := !isAWSManagedRole(role)
 				var policyDoc *string
 				// Get policy document if it's customer managed
 				if isCustomerManaged {
@@ -215,11 +213,6 @@ func getPolicyDocument(ctx context.Context, client *iamaws.Client, policyArn str
 	}
 
 	return &decodedDoc, nil
-}
-
-// isAWSManagedPolicy checks if a policy ARN represents an AWS managed policy
-func isAWSManagedPolicy(arn string) bool {
-	return len(arn) > 13 && arn[:13] == "arn:aws:iam::"
 }
 
 // Resource discovery functions with deduplication
@@ -347,13 +340,13 @@ func isControlTowerRole(role types.Role) bool {
 	return role.RoleName != nil && *role.RoleName == "AWSControlTowerExecution"
 }
 
-// isDefaultAwsRole returns true if the role is AWS-shipped (created and managed by AWS).
+// isAWSManagedRole returns true if the role is AWS-shipped (created and managed by AWS).
 //
 // This includes:
 //   - Service-linked roles
 //   - IAM Identity Center (SSO) roles
 //   - Control Tower roles
-func isDefaultAwsRole(role types.Role) bool {
+func isAWSManagedRole(role types.Role) bool {
 	return isServiceLinkedRole(role) ||
 		isIdentityCenterRole(role) ||
 		isControlTowerRole(role)

--- a/internal/lambda/lambda.go
+++ b/internal/lambda/lambda.go
@@ -49,7 +49,7 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 	}
 
 	var vpcReference *common.VpcReference
-	if function.VpcConfig != nil {
+	if function.VpcConfig != nil && function.VpcConfig.VpcId != nil {
 		vpcReference = createVpcReference(*function.VpcConfig.VpcId, function.VpcConfig.SubnetIds, region)
 	}
 
@@ -88,8 +88,25 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 		return nil, errors.New("function revision id is nil")
 	}
 
-	if function.Handler == nil {
-		return nil, errors.New("function handler is nil")
+	// Handler can be nil for container-image-based Lambda functions
+	var handler string
+	if function.Handler != nil {
+		handler = *function.Handler
+	}
+
+	var timeoutInSeconds int
+	if function.Timeout != nil {
+		timeoutInSeconds = int(*function.Timeout)
+	}
+
+	var memorySizeInMb int
+	if function.MemorySize != nil {
+		memorySizeInMb = int(*function.MemorySize)
+	}
+
+	var ephemeralStorageInMb int
+	if function.EphemeralStorage != nil && function.EphemeralStorage.Size != nil {
+		ephemeralStorageInMb = int(*function.EphemeralStorage.Size)
 	}
 
 	var result = &lambdafern.LambdaFunction{
@@ -101,11 +118,11 @@ func parseLambdaFunctionConfiguration(ctx context.Context, function types.Functi
 		Configuration: &lambdafern.LambdaConfigurationInfo{
 			RevisionId:           *function.RevisionId,
 			Runtime:              string(function.Runtime),
-			Handler:              *function.Handler,
+			Handler:              handler,
 			CodeSizeInBytes:      function.CodeSize,
-			TimeoutInSeconds:     int(*function.Timeout),
-			MemorySizeInMb:       int(*function.MemorySize),
-			EphemeralStorageInMb: int(*function.EphemeralStorage.Size),
+			TimeoutInSeconds:     timeoutInSeconds,
+			MemorySizeInMb:       memorySizeInMb,
+			EphemeralStorageInMb: ephemeralStorageInMb,
 			LastModified:         lastModified,
 			PackageType:          lambdaPackageType,
 			Description:          function.Description,
@@ -136,7 +153,7 @@ func enumerateLambdaForRegion(ctx context.Context, awsConfig aws.Config, region 
 	var functions []*lambdafern.LambdaFunction
 	var errors []error
 	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(context.TODO())
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			log.Error("Failed to get next page of Lambda functions",
 				svc1log.SafeParam("region", region),

--- a/internal/loadbalancer/enumerate/elbv1.go
+++ b/internal/loadbalancer/enumerate/elbv1.go
@@ -126,16 +126,6 @@ func targetsForLoadBalancerV1(loadBalancer types.LoadBalancerDescription) ([]*lo
 	targets := []*loadbalancerfern.Target{}
 	errorMessages := []string{}
 
-	// Build a map of instance port from BackendServerDescriptions for port lookup.
-	// BackendServerDescriptions only contains entries for instances with custom policies,
-	// so it will typically have fewer entries than Instances.
-	backendPortMap := make(map[int32]int32)
-	for _, backend := range loadBalancer.BackendServerDescriptions {
-		if backend.InstancePort != nil {
-			backendPortMap[*backend.InstancePort] = *backend.InstancePort
-		}
-	}
-
 	for _, instance := range loadBalancer.Instances {
 		targetType := loadbalancerfern.TargetTypeInstance
 		target := &loadbalancerfern.Target{

--- a/internal/loadbalancer/enumerate/elbv1.go
+++ b/internal/loadbalancer/enumerate/elbv1.go
@@ -57,7 +57,7 @@ func enumerateV1LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 			errorMsg := fmt.Sprintf("Failed to list v1 load balancers in region %s: %s", region, err.Error())
 			log.Error("Error listing v1 load balancers", svc1log.SafeParam("error", err.Error()), svc1log.SafeParam("region", region))
 			errorMessages = append(errorMessages, errorMsg)
-			return loadBalancers, errorMessages
+			break
 		}
 
 		for _, lb := range page.LoadBalancerDescriptions {
@@ -126,26 +126,30 @@ func targetsForLoadBalancerV1(loadBalancer types.LoadBalancerDescription) ([]*lo
 	targets := []*loadbalancerfern.Target{}
 	errorMessages := []string{}
 
-	if len(loadBalancer.Instances) == len(loadBalancer.BackendServerDescriptions) {
-		for i, instance := range loadBalancer.Instances {
-			backendServer := loadBalancer.BackendServerDescriptions[i]
-			var port *int
-			if backendServer.InstancePort != nil {
-				portValue := int(*backendServer.InstancePort)
-				port = &portValue
-			}
-			targetType := loadbalancerfern.TargetTypeInstance
-			target := &loadbalancerfern.Target{
-				Id:   aws.ToString(instance.InstanceId),
-				Type: &targetType, // Classic ELB can only point to EC2 instances
-				Port: port,
-			}
-			targets = append(targets, target)
+	// Build a map of instance port from BackendServerDescriptions for port lookup.
+	// BackendServerDescriptions only contains entries for instances with custom policies,
+	// so it will typically have fewer entries than Instances.
+	backendPortMap := make(map[int32]int32)
+	for _, backend := range loadBalancer.BackendServerDescriptions {
+		if backend.InstancePort != nil {
+			backendPortMap[*backend.InstancePort] = *backend.InstancePort
 		}
-	} else {
-		errorMessages = append(errorMessages, fmt.Sprintf("Mismatch between instances (%d) and backend server descriptions (%d) for load balancer %s",
-			len(loadBalancer.Instances), len(loadBalancer.BackendServerDescriptions), aws.ToString(loadBalancer.LoadBalancerName)))
 	}
+
+	for _, instance := range loadBalancer.Instances {
+		targetType := loadbalancerfern.TargetTypeInstance
+		target := &loadbalancerfern.Target{
+			Id:   aws.ToString(instance.InstanceId),
+			Type: &targetType,
+		}
+		// Use the listener instance port if available from the load balancer's listener descriptions
+		if len(loadBalancer.ListenerDescriptions) > 0 && loadBalancer.ListenerDescriptions[0].Listener != nil && loadBalancer.ListenerDescriptions[0].Listener.InstancePort != nil {
+			portValue := int(*loadBalancer.ListenerDescriptions[0].Listener.InstancePort)
+			target.Port = &portValue
+		}
+		targets = append(targets, target)
+	}
+
 	return targets, errorMessages
 }
 

--- a/internal/loadbalancer/enumerate/elbv2.go
+++ b/internal/loadbalancer/enumerate/elbv2.go
@@ -71,7 +71,7 @@ func enumerateV2LoadBalancersForRegion(ctx context.Context, cfg aws.Config, regi
 			errorMsg := fmt.Sprintf("Failed to list v2 load balancers in region %s: %s", region, err.Error())
 			log.Error("Error listing v2 load balancers", svc1log.SafeParam("error", err.Error()), svc1log.SafeParam("region", region))
 			errorMessages = append(errorMessages, errorMsg)
-			return loadBalancers, errorMessages
+			break
 		}
 
 		for _, lb := range page.LoadBalancers {

--- a/internal/rds/enumerate.go
+++ b/internal/rds/enumerate.go
@@ -72,12 +72,13 @@ func enumerateRDSForRegion(ctx context.Context, awsConfig aws.Config, region str
 	var errors []string
 
 	// List RDS instances
-	instances, err := listRDSInstances(ctx, rdsClient)
-	if err != nil {
-		errorMsg := "Failed to list RDS instances in region " + region + ": " + err.Error()
-		log.Error("Error listing RDS instances", svc1log.SafeParam("error", err.Error()))
-		errors = append(errors, errorMsg)
-		return nil, errors
+	instances, listErrors := listRDSInstances(ctx, rdsClient)
+	if len(listErrors) > 0 {
+		for _, e := range listErrors {
+			errorMsg := "Failed to list RDS instances in region " + region + ": " + e
+			log.Warn("Error listing RDS instances", svc1log.SafeParam("error", e))
+			errors = append(errors, errorMsg)
+		}
 	}
 
 	log.Info("Successfully listed RDS instances", svc1log.SafeParam("count", len(instances)))
@@ -101,20 +102,22 @@ func enumerateRDSForRegion(ctx context.Context, awsConfig aws.Config, region str
 	return rdsInstances, errors
 }
 
-func listRDSInstances(ctx context.Context, rdsClient *rds.Client) ([]types.DBInstance, error) {
+func listRDSInstances(ctx context.Context, rdsClient *rds.Client) ([]types.DBInstance, []string) {
 	var instances []types.DBInstance
+	var errors []string
 	paginator := rds.NewDescribeDBInstancesPaginator(rdsClient, &rds.DescribeDBInstancesInput{})
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			errors = append(errors, err.Error())
+			break
 		}
 
 		instances = append(instances, page.DBInstances...)
 	}
 
-	return instances, nil
+	return instances, errors
 }
 
 // convertAWSDBInstanceToFern converts an AWS RDS DB Instance to a Fern RDS Instance

--- a/internal/route53/enumerate.go
+++ b/internal/route53/enumerate.go
@@ -4,6 +4,7 @@ package route53
 import (
 	// Standard
 	"context"
+	"fmt"
 	"strings"
 
 	// Generated
@@ -23,9 +24,10 @@ const (
 	REGION = "us-east-1"
 )
 
-func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]route53fern.EnrichedHostedZone, error) {
+func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]route53fern.EnrichedHostedZone, []string) {
 	log := svc1log.FromContext(ctx)
 	var zones []route53fern.EnrichedHostedZone
+	var errors []string
 
 	log.Info("Starting Route53 hosted zones enumeration")
 	paginator := route53.NewListHostedZonesPaginator(route53Client, &route53.ListHostedZonesInput{})
@@ -34,7 +36,8 @@ func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]rout
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			log.Error("Failed to get next page of hosted zones", svc1log.Stacktrace(err))
-			return nil, err
+			errors = append(errors, fmt.Sprintf("Failed to get next page of hosted zones: %s", err.Error()))
+			break
 		}
 
 		log.Info("Retrieved hosted zones page", svc1log.SafeParam("zoneCount", len(page.HostedZones)))
@@ -90,13 +93,12 @@ func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]rout
 
 			log.Info("Processing hosted zone", svc1log.SafeParam("zoneName", identification.Name), svc1log.SafeParam("zoneId", identification.Id))
 
-			resourceRecordSets, err := listDNSRecords(ctx, route53Client, identification.Id)
-			if err != nil {
-				log.Error("Failed to get DNS records for hosted zone",
+			resourceRecordSets, dnsErrors := listDNSRecords(ctx, route53Client, identification.Id)
+			if len(dnsErrors) > 0 {
+				log.Warn("Errors getting DNS records for hosted zone",
 					svc1log.SafeParam("zoneName", identification.Name),
-					svc1log.SafeParam("zoneId", identification.Id),
-					svc1log.Stacktrace(err))
-				return nil, err
+					svc1log.SafeParam("zoneId", identification.Id))
+				errors = append(errors, dnsErrors...)
 			}
 
 			// Add resources if there are record sets
@@ -119,12 +121,13 @@ func listHostedZones(ctx context.Context, route53Client *route53.Client) ([]rout
 	}
 
 	log.Info("Completed Route53 hosted zones enumeration", svc1log.SafeParam("totalZones", len(zones)))
-	return zones, nil
+	return zones, errors
 }
 
-func listDNSRecords(ctx context.Context, route53Client *route53.Client, zoneID string) ([]*route53fern.ResourceRecordSet, error) {
+func listDNSRecords(ctx context.Context, route53Client *route53.Client, zoneID string) ([]*route53fern.ResourceRecordSet, []string) {
 	log := svc1log.FromContext(ctx)
 	var recordSets []*route53fern.ResourceRecordSet
+	var errors []string
 
 	log.Info("Retrieving DNS records for zone", svc1log.SafeParam("zoneId", zoneID))
 
@@ -140,7 +143,8 @@ func listDNSRecords(ctx context.Context, route53Client *route53.Client, zoneID s
 			log.Error("Failed to get next page of DNS records",
 				svc1log.SafeParam("zoneId", zoneID),
 				svc1log.Stacktrace(err))
-			return nil, err
+			errors = append(errors, fmt.Sprintf("Failed to get DNS records for zone %s: %s", zoneID, err.Error()))
+			break
 		}
 
 		log.Info("Retrieved DNS records page",
@@ -232,7 +236,7 @@ func listDNSRecords(ctx context.Context, route53Client *route53.Client, zoneID s
 		svc1log.SafeParam("zoneId", zoneID),
 		svc1log.SafeParam("totalRecords", len(recordSets)))
 
-	return recordSets, nil
+	return recordSets, errors
 }
 
 // EnumerateRoute53 retrieves all Route 53 hosted zones available to the caller and returns a Route53EnumerateReport struct
@@ -254,12 +258,12 @@ func EnumerateRoute53(ctx context.Context, awscfg aws.Config, config route53fern
 	route53Client := route53.NewFromConfig(awscfg)
 
 	// List hosted zones
-	hostedZones, err := listHostedZones(ctx, route53Client)
-	if err != nil {
-		log.Error("Failed to list hosted zones",
+	hostedZones, zoneErrors := listHostedZones(ctx, route53Client)
+	if len(zoneErrors) > 0 {
+		log.Warn("Errors occurred while listing hosted zones",
 			svc1log.SafeParam("region", awscfg.Region),
-			svc1log.Stacktrace(err))
-		errors = append(errors, err.Error())
+			svc1log.SafeParam("errorCount", len(zoneErrors)))
+		errors = append(errors, zoneErrors...)
 	}
 
 	// Add hosted zones to report

--- a/internal/s3/enumerate.go
+++ b/internal/s3/enumerate.go
@@ -66,6 +66,7 @@ func objectVersioning(ctx context.Context, s3Client *s3.Client, bucket *s3fern.S
 	result, err := s3Client.GetBucketVersioning(ctx, input)
 	if err != nil {
 		errors = append(errors, err.Error())
+		return bucket, errors
 	}
 
 	if result.Status != "" {

--- a/internal/s3/list.go
+++ b/internal/s3/list.go
@@ -37,7 +37,7 @@ func ListS3Bucket(ctx context.Context, awscfg aws.Config, config s3fern.ListS3Bu
 	pageCount := 0
 	for paginator.HasMorePages() {
 		pageCount++
-		output, err := paginator.NextPage(context.Background())
+		output, err := paginator.NextPage(ctx)
 		if err != nil {
 			log.Error("Error fetching page from S3 bucket",
 				svc1log.SafeParam("bucketName", config.BucketName),

--- a/internal/securitygroup/enumerate.go
+++ b/internal/securitygroup/enumerate.go
@@ -264,11 +264,14 @@ func convertAWSEC2SecurityGroupToFern(ctx context.Context, cfg aws.Config, awsSG
 		}
 
 		// Extract referenced security group (missing bidirectional connection!)
-		if rule.ReferencedGroupInfo != nil {
-			fernPerm.Configuration.Peer.ReferencedSecurityGroup = &fernsecuritygroup.ReferencedSecurityGroup{
+		if rule.ReferencedGroupInfo != nil && rule.ReferencedGroupInfo.GroupId != nil {
+			refSG := &fernsecuritygroup.ReferencedSecurityGroup{
 				GroupId: *rule.ReferencedGroupInfo.GroupId,
-				UserId:  *rule.ReferencedGroupInfo.UserId,
 			}
+			if rule.ReferencedGroupInfo.UserId != nil {
+				refSG.UserId = *rule.ReferencedGroupInfo.UserId
+			}
+			fernPerm.Configuration.Peer.ReferencedSecurityGroup = refSG
 		}
 
 		if len(cidrs) == 0 && fernPerm.Configuration.Peer.ReferencedSecurityGroup == nil {

--- a/internal/waf/enumerate.go
+++ b/internal/waf/enumerate.go
@@ -63,20 +63,32 @@ func enumerateWAFForRegion(ctx context.Context, awsConfig aws.Config, region str
 	wafClient := wafv2.NewFromConfig(awsConfig)
 	var errors []string
 
-	// List WAF WebACLs
-	listWebACLsInput := &wafv2.ListWebACLsInput{Scope: types.ScopeRegional}
-	webACLsOutput, err := wafClient.ListWebACLs(ctx, listWebACLsInput)
-	if err != nil {
-		errorMsg := "Failed to list WAF WebACLs in region " + region + ": " + err.Error()
-		log.Error("Error listing WAF WebACLs", svc1log.SafeParam("error", err.Error()))
-		errors = append(errors, errorMsg)
-		return nil, errors
+	// List WAF WebACLs with pagination
+	var allWebACLs []types.WebACLSummary
+	var nextMarker *string
+	for {
+		listWebACLsInput := &wafv2.ListWebACLsInput{
+			Scope:      types.ScopeRegional,
+			NextMarker: nextMarker,
+		}
+		webACLsOutput, err := wafClient.ListWebACLs(ctx, listWebACLsInput)
+		if err != nil {
+			errorMsg := "Failed to list WAF WebACLs in region " + region + ": " + err.Error()
+			log.Error("Error listing WAF WebACLs", svc1log.SafeParam("error", err.Error()))
+			errors = append(errors, errorMsg)
+			break
+		}
+		allWebACLs = append(allWebACLs, webACLsOutput.WebACLs...)
+		if webACLsOutput.NextMarker == nil {
+			break
+		}
+		nextMarker = webACLsOutput.NextMarker
 	}
 
-	log.Info("Successfully listed WAF WebACLs", svc1log.SafeParam("count", len(webACLsOutput.WebACLs)))
+	log.Info("Successfully listed WAF WebACLs", svc1log.SafeParam("count", len(allWebACLs)))
 
 	var wafs []*waffern.WafInstance
-	for _, webACL := range webACLsOutput.WebACLs {
+	for _, webACL := range allWebACLs {
 		// check if WAF has an ID
 		if webACL.ARN == nil {
 			log.Warn("WAF WebACL ARN is nil", svc1log.SafeParam("webACL", webACL))
@@ -267,9 +279,14 @@ func getStatementType(statement *types.Statement) waffern.StatementType {
 
 // Resource discovery functions
 func discoverLoadBalancerFromWebACL(ctx context.Context, wafClient *wafv2.Client, webACLArn *string, region string) *common.LoadBalancerReference {
+	log := svc1log.FromContext(ctx)
 	listResourcesInput := &wafv2.ListResourcesForWebACLInput{WebACLArn: webACLArn}
 	listResourcesOutput, err := wafClient.ListResourcesForWebACL(ctx, listResourcesInput)
 	if err != nil {
+		log.Warn("Failed to list resources for WebACL (LB discovery)",
+			svc1log.SafeParam("webACLArn", aws.ToString(webACLArn)),
+			svc1log.SafeParam("region", region),
+			svc1log.Stacktrace(err))
 		return nil
 	}
 
@@ -295,9 +312,14 @@ func discoverLoadBalancerFromWebACL(ctx context.Context, wafClient *wafv2.Client
 
 // discoverAPIGatewayFromWebACL discovers the API Gateway from the WebACL
 func discoverAPIGatewayFromWebACL(ctx context.Context, wafClient *wafv2.Client, webACLArn *string, region string) *common.ApiGatewayReference {
+	log := svc1log.FromContext(ctx)
 	listResourcesInput := &wafv2.ListResourcesForWebACLInput{WebACLArn: webACLArn}
 	listResourcesOutput, err := wafClient.ListResourcesForWebACL(ctx, listResourcesInput)
 	if err != nil {
+		log.Warn("Failed to list resources for WebACL (API GW discovery)",
+			svc1log.SafeParam("webACLArn", aws.ToString(webACLArn)),
+			svc1log.SafeParam("region", region),
+			svc1log.Stacktrace(err))
 		return nil
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple AWS enumerators (IAM, API Gateway, EC2/EKS/RDS, Route53, WAF, load balancers, S3, Lambda) to change pagination and error semantics, which can affect completeness/performance and downstream expectations. IAM now fetches attached policy documents for all policies and adds a new exclude flag, increasing API call volume and potential permission/throttling failures.
> 
> **Overview**
> Improves AWS resource enumeration robustness by adding missing pagination (API Gateway v1/v2 routes/domains/keys/plans, EKS clusters, WAF WebACLs) and switching several list helpers to **return partial results plus accumulated errors** instead of failing fast (EC2, RDS, Route53, load balancers, Route53 DNS records).
> 
> Renames IAM’s exclude option from *default roles* to **AWS-managed roles** (`exclude-aws-managed-roles`), updates the Fern config schema accordingly, and removes the `isCustomerManaged` policy flag while attempting to retrieve policy documents for all attached role policies.
> 
> Hardens multiple enumerators against nil fields and improves context propagation (e.g., Lambda container functions with nil `Handler`, optional VPC/timeout/memory/ephemeral storage, EKS certificate authority checks, SecurityGroup referenced group fields, and using request `ctx` for S3/Lambda paginators).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 995b6a3485e1745b89047379af91e5b70e5c886d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->