### PR TITLE
Update IAM Fern

### DIFF
--- a/fern/definition/iam/enumerate.yml
+++ b/fern/definition/iam/enumerate.yml
@@ -23,7 +23,7 @@ types:
   AttachedPolicy:
     properties:
       identification: AttachedPolicyIdentificationInfo
-      configuration: AttachedPolicyConfigurationInfo
+      configuration: optional<AttachedPolicyConfigurationInfo>
 # IAM Role High level structs
   IamRoleIdentificationInfo:
     properties:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema change that only relaxes a required field; main risk is downstream generated clients/validators accepting missing `configuration` where code previously assumed it was always present.
> 
> **Overview**
> Updates the IAM Fern definition so `AttachedPolicy.configuration` is now `optional<AttachedPolicyConfigurationInfo>` instead of required, allowing attached policies to be represented without a configuration block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9f27393ad145c63c94b7457f05778304802865d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->