### PR TITLE
IPv6 Support

### DIFF
--- a/internal/apigateway/enumerate/enumerate.go
+++ b/internal/apigateway/enumerate/enumerate.go
@@ -2,6 +2,7 @@ package apigateway
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	apigatewayfern "github.com/Method-Security/methodaws/generated/go/apigateway"
@@ -149,8 +150,12 @@ func extractDNSNameFromURI(uri string) string {
 	if strings.Contains(uri, "://") {
 		parts := strings.Split(uri, "://")
 		if len(parts) > 1 {
-			host := strings.Split(parts[1], "/")[0]
-			return strings.Split(host, ":")[0] // Remove port if present
+			hostport := strings.Split(parts[1], "/")[0]
+			// Use net.SplitHostPort to correctly handle IPv6 addresses (e.g. [::1]:8080)
+			if host, _, err := net.SplitHostPort(hostport); err == nil {
+				return host
+			}
+			return hostport
 		}
 	}
 	return uri

--- a/internal/vpc/enumerate.go
+++ b/internal/vpc/enumerate.go
@@ -285,6 +285,16 @@ func convertAWSSubnetToFern(awsSubnet ec2types.Subnet, region string) (*vpcfern.
 		}
 	}
 
+	// Convert subnet IPv6 CIDR block associations
+	var subnetCidrAssociations []*vpcfern.VpcCidrBlockAssociation
+
+	for _, assoc := range awsSubnet.Ipv6CidrBlockAssociationSet {
+		subnetCidrAssociations = append(subnetCidrAssociations, &vpcfern.VpcCidrBlockAssociation{
+			AssociationId: aws.ToString(assoc.AssociationId),
+			CidrBlock:     aws.ToString(assoc.Ipv6CidrBlock),
+		})
+	}
+
 	subnet := &vpcfern.Subnet{
 		Identification: &vpcfern.SubnetIdentificationInfo{
 			Id:     *awsSubnet.SubnetId,
@@ -310,7 +320,8 @@ func convertAWSSubnetToFern(awsSubnet ec2types.Subnet, region string) (*vpcfern.
 			Tags:                          tags,
 		},
 		Resources: &vpcfern.SubnetResourceInfo{
-			CidrBlock: awsSubnet.CidrBlock,
+			CidrBlock:               awsSubnet.CidrBlock,
+			CidrBlockAssociationSet: subnetCidrAssociations,
 		},
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly additive schema/output changes, but they modify generated API types and enumeration results, which could impact downstream consumers expecting the previous shape. Minor logic changes in URI parsing and address collection may have edge cases around host/port formatting.
> 
> **Overview**
> Adds **IPv6/dual-stack fields** to the Fern schemas and enumeration output: EC2 instance `dnsData` and network interfaces now include `ipv6Addresses`, and EKS service resources now expose `clusterIpAddresses` in addition to the primary `clusterIpAddress`.
> 
> Updates enumerators to populate these new fields (collecting IPv6s from EC2 ENIs, emitting all Kubernetes `spec.clusterIPs`) and extends VPC subnet resources to include IPv6 CIDR block associations. Also fixes API Gateway `extractDNSNameFromURI` to correctly parse IPv6 host:port URIs using `net.SplitHostPort`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36cfe5347256b0c9ca243c45b10249087c143c2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->