### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.78.1"
+  "version": "4.68.4"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,9 +3,9 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.38.0
+        version: 1.34.5
         config:
-          importpath: github.com/Method-Security/methodaws/generated/go
+          importPath: github.com/Method-Security/methodaws/generated/go
         output:
           location: local-file-system
           path: ../generated/go

--- a/internal/apigateway/enumerate/apigwv1.go
+++ b/internal/apigateway/enumerate/apigwv1.go
@@ -336,9 +336,9 @@ func convertV1Integration(methodIntegration *types.Integration, region string) (
 			IsExternal: !strings.Contains(*methodIntegration.Uri, ".amazonaws.com"),
 		}
 
-		return apigatewayfern.NewIntegrationFromHttp(&apigatewayfern.HttpIntegration{
+		return &apigatewayfern.Integration{Type: "http", Http: &apigatewayfern.HttpIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeAws:
 		if methodIntegration.Uri == nil {
@@ -351,9 +351,9 @@ func convertV1Integration(methodIntegration *types.Integration, region string) (
 			Region:  region,
 		}
 
-		return apigatewayfern.NewIntegrationFromAws(&apigatewayfern.AwsIntegration{
+		return &apigatewayfern.Integration{Type: "aws", Aws: &apigatewayfern.AwsIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeHttpProxy:
 		if methodIntegration.Uri == nil {
@@ -363,9 +363,9 @@ func convertV1Integration(methodIntegration *types.Integration, region string) (
 		// Check if this is a VPC Link integration (private load balancer)
 		if isVpcLinkIntegration(methodIntegration) {
 			backend := createLoadBalancerBackend(methodIntegration, region)
-			return apigatewayfern.NewIntegrationFromVpcLink(&apigatewayfern.VpcLinkIntegration{
+			return &apigatewayfern.Integration{Type: "vpc_link", VpcLink: &apigatewayfern.VpcLinkIntegration{
 				Backend: backend,
-			}), nil
+			}}, nil
 		}
 
 		backend := &apigatewayfern.HttpBackend{
@@ -373,9 +373,9 @@ func convertV1Integration(methodIntegration *types.Integration, region string) (
 			IsExternal: !strings.Contains(*methodIntegration.Uri, ".amazonaws.com"),
 		}
 
-		return apigatewayfern.NewIntegrationFromHttpProxy(&apigatewayfern.HttpProxyIntegration{
+		return &apigatewayfern.Integration{Type: "http_proxy", HttpProxy: &apigatewayfern.HttpProxyIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeAwsProxy:
 		if methodIntegration.Uri == nil {
@@ -388,15 +388,15 @@ func convertV1Integration(methodIntegration *types.Integration, region string) (
 			Region:       region,
 		}
 
-		return apigatewayfern.NewIntegrationFromAwsProxy(&apigatewayfern.AwsProxyIntegration{
+		return &apigatewayfern.Integration{Type: "aws_proxy", AwsProxy: &apigatewayfern.AwsProxyIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeMock:
 		backend := &apigatewayfern.MockBackend{}
-		return apigatewayfern.NewIntegrationFromMock(&apigatewayfern.MockIntegration{
+		return &apigatewayfern.Integration{Type: "mock", Mock: &apigatewayfern.MockIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported integration type: %s", methodIntegration.Type)

--- a/internal/apigateway/enumerate/apigwv2.go
+++ b/internal/apigateway/enumerate/apigwv2.go
@@ -325,9 +325,9 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 		if integration.ConnectionType == types.ConnectionTypeVpcLink &&
 			integration.ConnectionId != nil {
 			backend := createV2LoadBalancerBackend(integration, region)
-			return apigatewayfern.NewIntegrationFromVpcLink(&apigatewayfern.VpcLinkIntegration{
+			return &apigatewayfern.Integration{Type: "vpc_link", VpcLink: &apigatewayfern.VpcLinkIntegration{
 				Backend: backend,
-			}), nil
+			}}, nil
 		}
 
 		backend := &apigatewayfern.HttpBackend{
@@ -335,9 +335,9 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 			IsExternal: !strings.Contains(uri, ".amazonaws.com"),
 		}
 
-		return apigatewayfern.NewIntegrationFromHttp(&apigatewayfern.HttpIntegration{
+		return &apigatewayfern.Integration{Type: "http", Http: &apigatewayfern.HttpIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeAws:
 		arn := aws.ToString(integration.IntegrationUri)
@@ -347,9 +347,9 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 			Region:  region,
 		}
 
-		return apigatewayfern.NewIntegrationFromAws(&apigatewayfern.AwsIntegration{
+		return &apigatewayfern.Integration{Type: "aws", Aws: &apigatewayfern.AwsIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeHttpProxy:
 		uri := aws.ToString(integration.IntegrationUri)
@@ -358,9 +358,9 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 		if integration.ConnectionType == types.ConnectionTypeVpcLink &&
 			integration.ConnectionId != nil {
 			backend := createV2LoadBalancerBackend(integration, region)
-			return apigatewayfern.NewIntegrationFromVpcLink(&apigatewayfern.VpcLinkIntegration{
+			return &apigatewayfern.Integration{Type: "vpc_link", VpcLink: &apigatewayfern.VpcLinkIntegration{
 				Backend: backend,
-			}), nil
+			}}, nil
 		}
 
 		backend := &apigatewayfern.HttpBackend{
@@ -368,9 +368,9 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 			IsExternal: !strings.Contains(uri, ".amazonaws.com"),
 		}
 
-		return apigatewayfern.NewIntegrationFromHttpProxy(&apigatewayfern.HttpProxyIntegration{
+		return &apigatewayfern.Integration{Type: "http_proxy", HttpProxy: &apigatewayfern.HttpProxyIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeAwsProxy:
 		arn := aws.ToString(integration.IntegrationUri)
@@ -380,15 +380,15 @@ func convertV2Integration(integration *apigatewayv2.GetIntegrationOutput, region
 			Region:       region,
 		}
 
-		return apigatewayfern.NewIntegrationFromAwsProxy(&apigatewayfern.AwsProxyIntegration{
+		return &apigatewayfern.Integration{Type: "aws_proxy", AwsProxy: &apigatewayfern.AwsProxyIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	case types.IntegrationTypeMock:
 		backend := &apigatewayfern.MockBackend{}
-		return apigatewayfern.NewIntegrationFromMock(&apigatewayfern.MockIntegration{
+		return &apigatewayfern.Integration{Type: "mock", Mock: &apigatewayfern.MockIntegration{
 			Backend: backend,
-		}), nil
+		}}, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported integration type: %s", integration.IntegrationType)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a major Fern/go-sdk generator upgrade that can change generated types/serialization, plus updates to integration union construction that could affect downstream consumers if the union tags/fields differ.
> 
> **Overview**
> Upgrades Fern (`fern.config.json` 3.78.1 → 4.68.4) and the Go SDK generator (`fern-go-sdk` 0.38.0 → 1.34.5), including a config key rename from `importpath` to `importPath`.
> 
> Updates API Gateway v1/v2 integration conversion (`convertV1Integration`, `convertV2Integration`) to construct `apigatewayfern.Integration` unions directly (setting `Type` and the corresponding variant field) instead of using `NewIntegrationFrom*` helpers, aligning with the regenerated SDK types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff4da2e865677b3d22ec265276fa371ad1a099d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->