### PR TITLE
Bump Go stdlib requirement to 1.26.3

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.3"
 
 jobs:
   # Build ARM64 using native GitHub ARM runner but inside Docker for Alpine compatibility

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
 
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled methodaws binary
-FROM golang:1.26.0-alpine3.22 AS base
+FROM golang:1.26.3-alpine3.22 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="methodaws"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Method-Security/methodaws
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/Method-Security/pkg v0.0.6


### PR DESCRIPTION
> [!NOTE]
> **Low Risk**
> Toolchain-only version alignment with no application or dependency logic changes.
> 
> **Overview**
> Bumps the required Go toolchain from **1.26** / **1.26.0** to **1.26.3** so local builds, CI, and containerized releases use the same patch release.
> 
> `go.mod` now declares `go 1.26.3`. **Verify** and **reusable-build** workflows pin `setup-go` / `GO_VERSION` to **1.26.3**, and `Dockerfile.builder` uses `golang:1.26.3-alpine3.22` for Linux ARM64/AMD64 GoReleaser builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2096d37a48fb138d7454927486e133b317f9dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->