### PR TITLE
feat(s3/external): seed-based candidate bucket discovery

### DIFF
--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -90,6 +90,10 @@ func (a *MethodAws) InitS3Command() {
 				a.OutputSignal.AddError(fmt.Errorf("either --url or --target-seed must be provided"))
 				return
 			}
+			if bucketURL != "" && targetSeed != "" {
+				a.OutputSignal.AddError(fmt.Errorf("provide either --url or --target-seed, not both"))
+				return
+			}
 
 			// Check if specific region was provided via --region flag
 			// Overide since this is an external command and we dont want to default check all regions

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	// Standard
 	"fmt"
+	"strings"
 
 	// Internal
 	"github.com/Method-Security/methodaws/internal/s3"
@@ -75,6 +76,9 @@ func (a *MethodAws) InitS3Command() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			// A whitespace-only seed normalizes to zero candidates, so treat it
+			// as unset rather than silently completing with no probes.
+			targetSeed = strings.TrimSpace(targetSeed)
 
 			maxCandidates, err := cmd.Flags().GetInt("max-candidates")
 			if err != nil {

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	// Standard
+	"fmt"
+
 	// Internal
 	"github.com/Method-Security/methodaws/internal/s3"
 	"github.com/Method-Security/methodaws/utils"
@@ -67,6 +70,23 @@ func (a *MethodAws) InitS3Command() {
 				return
 			}
 
+			targetSeed, err := cmd.Flags().GetString("target-seed")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			maxCandidates, err := cmd.Flags().GetInt("max-candidates")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			if bucketURL == "" && targetSeed == "" {
+				a.OutputSignal.AddError(fmt.Errorf("either --url or --target-seed must be provided"))
+				return
+			}
+
 			// Check if specific region was provided via --region flag
 			// Overide since this is an external command and we dont want to default check all regions
 			regionFlag, err := cmd.Flags().GetString("region")
@@ -81,7 +101,7 @@ func (a *MethodAws) InitS3Command() {
 			}
 
 			// Get Config
-			config := getExternalS3BucketConfig(regions, bucketURL)
+			config := getExternalS3BucketConfig(regions, bucketURL, targetSeed, maxCandidates)
 
 			// Get Report
 			report := external.EnumerateS3(cmd.Context(), config)
@@ -90,10 +110,10 @@ func (a *MethodAws) InitS3Command() {
 	}
 
 	// Flags
-	externalCmd.Flags().String("url", "", "URL of the S3 bucket")
+	externalCmd.Flags().String("url", "", "URL of a single S3 bucket to enumerate")
 	externalCmd.Flags().String("region", "", "Region of the S3 bucket")
-
-	_ = externalCmd.MarkFlagRequired("url")
+	externalCmd.Flags().String("target-seed", "", "Org/domain seed used to generate and probe candidate bucket names")
+	externalCmd.Flags().Int("max-candidates", 50, "Max candidate bucket names to probe when --target-seed is set (cap 500)")
 
 	// Add Command to S3 Command
 	s3Cmd.AddCommand(externalCmd)
@@ -147,12 +167,20 @@ func (a *MethodAws) getS3EnumerateConfig(accountID string, regions []string) s3f
 	}
 }
 
-// getExternalS3BucketConfig returns a s3fern.ExternalS3BucketConfig with the given regions and bucket URL
-func getExternalS3BucketConfig(regions []string, bucketURL string) s3fern.S3ExternalConfig {
-	return s3fern.S3ExternalConfig{
-		Url:     bucketURL,
+// getExternalS3BucketConfig returns a s3fern.S3ExternalConfig for either a single
+// bucket URL or seed-based candidate discovery.
+func getExternalS3BucketConfig(regions []string, bucketURL string, targetSeed string, maxCandidates int) s3fern.S3ExternalConfig {
+	config := s3fern.S3ExternalConfig{
 		Regions: regions,
 	}
+	if bucketURL != "" {
+		config.Url = &bucketURL
+	}
+	if targetSeed != "" {
+		config.TargetSeed = &targetSeed
+		config.MaxCandidates = &maxCandidates
+	}
+	return config
 }
 
 // getS3ListConfig returns a s3fern.ListS3BucketConfig with the given regions, and bucket name

--- a/fern/definition/s3/external.yml
+++ b/fern/definition/s3/external.yml
@@ -4,8 +4,10 @@ types:
 # Config
   S3ExternalConfig:
     properties:
-      url: string
+      url: optional<string>
       regions: optional<list<string>>
+      targetSeed: optional<string>      # Seed (org/domain name) used to generate candidate bucket names to probe
+      maxCandidates: optional<integer>  # Max candidate names to probe when targetSeed is set (default 50, cap 500)
 # Supporting structs
   DirectoryContents:
     properties:

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -354,8 +354,9 @@ func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.Ext
 	result := s3fern.ExternalS3BucketResult{}
 	errors := []string{}
 
-	// Seed-based candidate discovery takes precedence when provided.
-	if config.TargetSeed != nil && *config.TargetSeed != "" {
+	// Seed-based candidate discovery takes precedence when provided. A
+	// whitespace-only seed normalizes to zero candidates, so treat it as unset.
+	if config.TargetSeed != nil && strings.TrimSpace(*config.TargetSeed) != "" {
 		seedResult, seedErrors := enumerateBySeed(ctx, config)
 		report.Result = seedResult
 		report.Errors = seedErrors

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -358,6 +358,14 @@ func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.Ext
 	// whitespace-only seed normalizes to zero candidates, so treat it as unset.
 	if config.TargetSeed != nil && strings.TrimSpace(*config.TargetSeed) != "" {
 		seedResult, seedErrors := enumerateBySeed(ctx, config)
+		if config.Url != nil && *config.Url != "" {
+			// The CLI rejects supplying both modes; a programmatic caller still can.
+			// Seed discovery wins, but surface the ignored url rather than silently
+			// dropping it so the caller is not misled into thinking it was probed.
+			log.Warn("Both url and targetSeed provided; enumerating by seed and ignoring url",
+				svc1log.SafeParam("url", *config.Url))
+			seedErrors = append(seedErrors, fmt.Sprintf("both url and targetSeed were provided; enumerated by seed and ignored url %q", *config.Url))
+		}
 		report.Result = seedResult
 		report.Errors = seedErrors
 		return report

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -344,17 +344,35 @@ func externalS3Region(ctx context.Context, bucketURL string, bucketName string, 
 	return &report, errors
 }
 
-// EnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials
+// EnumerateS3 attempts to enumerate a public facing S3 bucket with no credentials.
+// When TargetSeed is set, candidate bucket names are generated from the seed and
+// each is probed; otherwise a single bucket is enumerated from Url.
 func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.ExternalS3Report {
 	log := svc1log.FromContext(ctx)
-	log.Info("Starting external S3 enumeration", svc1log.SafeParam("bucketURL", config.Url))
 
 	report := s3fern.ExternalS3Report{Config: &config}
 	result := s3fern.ExternalS3BucketResult{}
 	errors := []string{}
 
+	// Seed-based candidate discovery takes precedence when provided.
+	if config.TargetSeed != nil && *config.TargetSeed != "" {
+		seedResult, seedErrors := enumerateBySeed(ctx, config)
+		report.Result = seedResult
+		report.Errors = seedErrors
+		return report
+	}
+
+	if config.Url == nil || *config.Url == "" {
+		report.Result = &result
+		report.Errors = []string{"either url or targetSeed must be provided"}
+		return report
+	}
+
+	bucketURL := *config.Url
+	log.Info("Starting external S3 enumeration", svc1log.SafeParam("bucketURL", bucketURL))
+
 	// Parse the bucket URL to get name and potentially region
-	bucketName, urlRegion := parseBucketURL(config.Url)
+	bucketName, urlRegion := parseBucketURL(bucketURL)
 
 	// If we got a region from the URL, only check that region
 	// First try user input, then URL region, then all regions if no input or URL region
@@ -382,7 +400,7 @@ func EnumerateS3(ctx context.Context, config s3fern.S3ExternalConfig) s3fern.Ext
 			log.Info("Found bucket in region",
 				svc1log.SafeParam("bucketName", bucketName),
 				svc1log.SafeParam("region", region))
-			functionResult, functionErrors := externalS3Region(ctx, config.Url, bucketName, region)
+			functionResult, functionErrors := externalS3Region(ctx, bucketURL, bucketName, region)
 			if functionResult != nil {
 				result = *functionResult
 			}

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -155,6 +155,14 @@ func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fe
 		svc1log.SafeParam("targetSeed", *config.TargetSeed),
 		svc1log.SafeParam("candidateCount", len(candidates)))
 
+	// A seed that normalizes to nothing probeable (e.g. "..") yields zero
+	// candidates. Surface that explicitly so an empty result is distinguishable
+	// from a successful run that simply found no public buckets.
+	if len(candidates) == 0 {
+		errors = append(errors, fmt.Sprintf("no valid S3 bucket-name candidates could be derived from target seed %q", *config.TargetSeed))
+		return result, errors
+	}
+
 	regionsToCheck := config.Regions
 	if len(regionsToCheck) == 0 {
 		regionsToCheck = seedProbeRegions
@@ -185,6 +193,12 @@ func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fe
 			errors = append(errors, functionErrors...)
 			break
 		}
+	}
+
+	// Mirror the single-URL path, which records an explicit not-found error so a
+	// caller can tell a genuine "no public buckets" result from failed discovery.
+	if len(result.ExternalBuckets) == 0 {
+		errors = append(errors, fmt.Sprintf("no public buckets found among %d candidate names derived from target seed %q", len(candidates), *config.TargetSeed))
 	}
 
 	log.Info("Completed seed-based S3 bucket discovery",

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -107,6 +107,11 @@ func candidateNames(targetSeed string, maxCandidates int) []string {
 				continue
 			}
 			seen[name] = struct{}{}
+			// Skip invalid names here so they don't consume a cap slot and
+			// starve real candidates further down the permutation list.
+			if !isValidBucketName(name) {
+				continue
+			}
 			candidates = append(candidates, name)
 			if len(candidates) >= maxCandidates {
 				return candidates
@@ -147,9 +152,6 @@ func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fe
 	}
 
 	for _, name := range candidates {
-		if !isValidBucketName(name) {
-			continue
-		}
 		for _, region := range regionsToCheck {
 			exists, err := bucketExists(ctx, region, name)
 			if err != nil {

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -1,0 +1,177 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	s3fern "github.com/Method-Security/methodaws/generated/go/s3"
+
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// permutationSuffixes mirrors the in-process bucket enumerator's seed expansion
+// patterns so seed-based discovery behaves consistently across both code paths.
+var permutationSuffixes = []string{
+	"", "-backup", "-prod", "-production", "-staging", "-stage", "-dev", "-test",
+	"-logs", "-log", "-artifacts", "-assets", "-static", "-public", "-private",
+	"-data", "-files", "-uploads", "-media", "-archive", "-backups", "-cdn",
+	"-web", "-app", "-config", "-terraform", "-tfstate", "-lambda", "-builds",
+	"-releases",
+}
+
+// seedProbeRegions is a bounded default region set used for seed discovery when
+// no explicit regions are configured, keeping the number of probe calls in check.
+var seedProbeRegions = []string{"us-east-1", "us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1"}
+
+const (
+	defaultMaxCandidates = 50
+	maxCandidatesCap     = 500
+)
+
+var (
+	nonAlnumRun     = regexp.MustCompile(`[^a-z0-9]+`)
+	nonDottedRun    = regexp.MustCompile(`[^a-z0-9.-]+`)
+	leadingWww      = regexp.MustCompile(`^www\.`)
+	validBucketName = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*[a-z0-9]$`)
+)
+
+// normalizeSeedVariants derives candidate base names from a seed (org name, domain
+// or URL), mirroring the in-process enumerator's variant generation.
+func normalizeSeedVariants(targetSeed string) []string {
+	seed := strings.ToLower(strings.TrimSpace(targetSeed))
+	if strings.Contains(seed, "://") {
+		seed = strings.SplitN(seed, "://", 2)[1]
+	}
+	seed = strings.SplitN(seed, "/", 2)[0]
+	seed = strings.SplitN(seed, ":", 2)[0]
+	seed = strings.Trim(seed, ".")
+	seed = leadingWww.ReplaceAllString(seed, "")
+
+	compact := strings.Trim(nonAlnumRun.ReplaceAllString(seed, "-"), "-")
+	noTld := compact
+	if strings.Contains(seed, ".") {
+		labels := []string{}
+		for _, label := range strings.Split(seed, ".") {
+			if label != "" {
+				labels = append(labels, label)
+			}
+		}
+		if len(labels) >= 2 {
+			noTld = strings.Trim(nonAlnumRun.ReplaceAllString(labels[len(labels)-2], "-"), "-")
+		}
+	}
+
+	variants := []string{compact, noTld, strings.ReplaceAll(compact, "-", ""), strings.ReplaceAll(noTld, "-", "")}
+	if strings.Contains(seed, ".") {
+		dotted := strings.Trim(nonDottedRun.ReplaceAllString(seed, "-"), "-.")
+		variants = append([]string{dotted}, variants...)
+	}
+
+	return dedupeNonEmpty(variants)
+}
+
+func dedupeNonEmpty(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+// candidateNames expands seed variants with permutation suffixes, capping the
+// result at maxCandidates (clamped to [1, 500]).
+func candidateNames(targetSeed string, maxCandidates int) []string {
+	if maxCandidates < 1 {
+		maxCandidates = 1
+	}
+	if maxCandidates > maxCandidatesCap {
+		maxCandidates = maxCandidatesCap
+	}
+
+	candidates := make([]string, 0, maxCandidates)
+	seen := make(map[string]struct{}, maxCandidates)
+	for _, base := range normalizeSeedVariants(targetSeed) {
+		for _, suffix := range permutationSuffixes {
+			name := base + suffix
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			candidates = append(candidates, name)
+			if len(candidates) >= maxCandidates {
+				return candidates
+			}
+		}
+	}
+	return candidates
+}
+
+func isValidBucketName(name string) bool {
+	return len(name) >= 3 && len(name) <= 63 &&
+		validBucketName.MatchString(name) &&
+		!strings.Contains(name, "..") &&
+		!strings.Contains(name, ".-") &&
+		!strings.Contains(name, "-.")
+}
+
+// enumerateBySeed generates candidate bucket names from the seed and runs the full
+// external enumeration against each candidate that resolves to an existing bucket.
+func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fern.ExternalS3BucketResult, []string) {
+	log := svc1log.FromContext(ctx)
+	result := &s3fern.ExternalS3BucketResult{}
+	errors := []string{}
+
+	maxCandidates := defaultMaxCandidates
+	if config.MaxCandidates != nil && *config.MaxCandidates > 0 {
+		maxCandidates = *config.MaxCandidates
+	}
+
+	candidates := candidateNames(*config.TargetSeed, maxCandidates)
+	log.Info("Starting seed-based S3 bucket discovery",
+		svc1log.SafeParam("targetSeed", *config.TargetSeed),
+		svc1log.SafeParam("candidateCount", len(candidates)))
+
+	regionsToCheck := config.Regions
+	if len(regionsToCheck) == 0 {
+		regionsToCheck = seedProbeRegions
+	}
+
+	for _, name := range candidates {
+		if !isValidBucketName(name) {
+			continue
+		}
+		for _, region := range regionsToCheck {
+			exists, err := bucketExists(ctx, region, name)
+			if err != nil {
+				// Probe errors are non-fatal during discovery; try the next region.
+				continue
+			}
+			if !exists {
+				continue
+			}
+			bucketURL := fmt.Sprintf("https://%s.s3.amazonaws.com", name)
+			functionResult, functionErrors := externalS3Region(ctx, bucketURL, name, region)
+			if functionResult != nil {
+				result.ExternalBuckets = append(result.ExternalBuckets, functionResult.ExternalBuckets...)
+			}
+			errors = append(errors, functionErrors...)
+			break
+		}
+	}
+
+	log.Info("Completed seed-based S3 bucket discovery",
+		svc1log.SafeParam("targetSeed", *config.TargetSeed),
+		svc1log.SafeParam("bucketsFound", len(result.ExternalBuckets)))
+
+	return result, errors
+}

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -35,6 +35,7 @@ var (
 	nonDottedRun    = regexp.MustCompile(`[^a-z0-9.-]+`)
 	leadingWww      = regexp.MustCompile(`^www\.`)
 	validBucketName = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*[a-z0-9]$`)
+	ipFormattedName = regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`)
 )
 
 // normalizeSeedVariants derives candidate base names from a seed (org name, domain
@@ -98,10 +99,15 @@ func candidateNames(targetSeed string, maxCandidates int) []string {
 		maxCandidates = maxCandidatesCap
 	}
 
+	variants := normalizeSeedVariants(targetSeed)
 	candidates := make([]string, 0, maxCandidates)
 	seen := make(map[string]struct{}, maxCandidates)
-	for _, base := range normalizeSeedVariants(targetSeed) {
-		for _, suffix := range permutationSuffixes {
+	// Iterate suffix-major so every variant's highest-value name (the bare org
+	// name, then -backup/-prod, ...) is probed before any variant's lower-priority
+	// suffix. A variant-major walk would let the first variant consume the whole
+	// cap and starve the bare names of later variants.
+	for _, suffix := range permutationSuffixes {
+		for _, base := range variants {
 			name := base + suffix
 			if _, ok := seen[name]; ok {
 				continue
@@ -124,6 +130,7 @@ func candidateNames(targetSeed string, maxCandidates int) []string {
 func isValidBucketName(name string) bool {
 	return len(name) >= 3 && len(name) <= 63 &&
 		validBucketName.MatchString(name) &&
+		!ipFormattedName.MatchString(name) &&
 		!strings.Contains(name, "..") &&
 		!strings.Contains(name, ".-") &&
 		!strings.Contains(name, "-.")
@@ -137,7 +144,9 @@ func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fe
 	errors := []string{}
 
 	maxCandidates := defaultMaxCandidates
-	if config.MaxCandidates != nil && *config.MaxCandidates > 0 {
+	if config.MaxCandidates != nil {
+		// Out-of-range values (<=0 or >cap) are clamped by candidateNames, so this
+		// path and the bare candidateNames call treat bad input identically.
 		maxCandidates = *config.MaxCandidates
 	}
 

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -155,7 +155,14 @@ func enumerateBySeed(ctx context.Context, config s3fern.S3ExternalConfig) (*s3fe
 		for _, region := range regionsToCheck {
 			exists, err := bucketExists(ctx, region, name)
 			if err != nil {
-				// Probe errors are non-fatal during discovery; try the next region.
+				// Probe errors are non-fatal during discovery (try the next region),
+				// but they must be surfaced so a region/API failure is distinguishable
+				// from a genuine not-found, mirroring the single-URL path.
+				log.Warn("Error checking candidate bucket in region",
+					svc1log.SafeParam("region", region),
+					svc1log.SafeParam("bucketName", name),
+					svc1log.Stacktrace(err))
+				errors = append(errors, fmt.Sprintf("Error checking bucket %s in region %s: %v", name, region, err))
 				continue
 			}
 			if !exists {


### PR DESCRIPTION
## Summary
Closes the cloud-bucket `target_seed` MCP parity gap for `awss3externalenumerate` so the Method tool can discover buckets from an org/domain seed, not just scan a single known bucket.

- **targetSeed**: generate candidate bucket names from a seed (mirrors the in-process enumerator's `_normalize_seed_variants` + the same 30 permutation suffixes), validate names, probe existence across a bounded region set, and run the full external enumeration on each hit
- **maxCandidates**: cap on probed candidates (default 50, max 500)
- **url is now optional** — either `url` or `targetSeed` must be provided (back-compatible: single-bucket path unchanged when `url` is given)

GCS/Azure seed discovery is deferred per scope. Generated bindings are gitignored and rebuilt by CI from the Fern definitions.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet` / `gofmt` / `go test ./internal/s3/...` clean
- [x] `s3 external --help` shows `--target-seed` / `--max-candidates`
- [ ] CI green (Fern regen + build + tests)
- [ ] Downstream: tag + publish so ontology can bump `methodaws` pin

Made with [Cursor](https://cursor.com)