### PR TITLE
Forbid extra fields in generated Pydantic models

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -14,6 +14,8 @@ groups:
     generators:
       - name: fernapi/fern-pydantic-model
         version: 1.11.2
+        config:
+          extra_fields: forbid
         output:
           location: local-file-system
           path: ../generated/python
@@ -24,6 +26,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodaws
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodaws
@@ -36,6 +39,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodaws
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodaws


### PR DESCRIPTION
## Summary

Set `extra_fields: forbid` on every `fern-pydantic-model` generator block (`pypi-local`, `pypi-test`, `pypi`) so the generated config types raise `pydantic.ValidationError` when constructed with unknown kwargs.

## Why

Today the generated models use `extra="allow"`, which silently accepts unknown kwargs and serializes them to the wire payload — that's how `stop_first_success` / `continue_on_error` slipped through the ontology compilers and broke against the v0.0.194 networkscan CLI ("unknown flag" → empty stdout → signal parse failed).

Strict mode (`extra="forbid"`) surfaces the same class of bug at **construction time** in the consumer (ontology compiler / tests), not at runtime on Jackal. Matches https://github.com/method-security/networkscan/pull/331 / https://github.com/method-security/webscan/pull/450 / https://github.com/method-security/osintscan/pull/161.

## What ships

`generated/python/` is gitignored — CI regenerates from `fern/generators.yml` at publish time, so this single-file change propagates to the next `methodaws` wheel automatically. Verified that `fern-pydantic-model 1.11.2` accepts the `extra_fields: forbid` config option.

## Migration note for consumers

After the next wheel publishes, any consumer that still passes unknown kwargs to a generated config will start failing pydantic validation at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for downstream code that still passes unknown kwargs to generated models; behavior only shifts after the next wheel publish.
> 
> **Overview**
> Configures all three `fern-pydantic-model` generator targets in `fern/generators.yml` (`pypi-local`, `pypi-test`, `pypi`) with **`extra_fields: forbid`**, so the next published `methodaws` wheel emits Pydantic models that reject unknown kwargs at construction time instead of allowing them on the wire.
> 
> For `pypi-local`, this also introduces a proper `config:` block for that option; test and production PyPI blocks merge `extra_fields: forbid` into their existing `package_name` config. **`generated/python/` is not in the diff** — consumers pick up the behavior on the next CI publish from this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18977a87ba2a3b7f3ede2e2792ffe05f51690c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->