### PR TITLE
Add http and socks proxy support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,9 +43,11 @@ func NewMethodAws(version string) *MethodAws {
 	methodAws := MethodAws{
 		Version: version,
 		RootFlags: config.RootFlags{
-			Quiet:   false,
-			Verbose: false,
-			Regions: []string{},
+			Quiet:      false,
+			Verbose:    false,
+			Regions:    []string{},
+			HTTPProxy:  "",
+			SOCKSProxy: "",
 		},
 		OutputConfig: writer.NewOutputConfig(nil, writer.NewFormat(writer.SIGNAL)),
 		OutputSignal: signal.NewSignal(nil, &startedAt, nil, 0, nil),
@@ -72,9 +74,18 @@ func (a *MethodAws) setupCommonConfig(cmd *cobra.Command, outputFormat string, o
 	}
 	a.OutputConfig = writer.NewOutputConfig(outputFilePointer, format)
 
-	cmd.SetContext(svc1log.WithLogger(cmd.Context(), config.InitializeLogging(cmd, &a.RootFlags)))
+	ctx := svc1log.WithLogger(cmd.Context(), config.InitializeLogging(cmd, &a.RootFlags))
+	ctx = config.SetProxyConfig(ctx, config.ProxyConfig{
+		HTTPProxy:  a.RootFlags.HTTPProxy,
+		SOCKSProxy: a.RootFlags.SOCKSProxy,
+	})
+	cmd.SetContext(ctx)
 	if authed {
-		awsConfig, err := awsconfig.LoadDefaultConfig(cmd.Context())
+		loadOptions, err := config.AWSLoadOptionsFromContext(cmd.Context())
+		if err != nil {
+			return err
+		}
+		awsConfig, err := awsconfig.LoadDefaultConfig(cmd.Context(), loadOptions...)
 		if err != nil {
 			return err
 		}
@@ -134,6 +145,8 @@ func (a *MethodAws) InitRootCommand() {
 	a.RootCmd.PersistentFlags().StringArrayVarP(&a.RootFlags.Regions, "regions", "r", []string{}, "AWS Regions to search for resources. You can specify multiple regions by providing the flag multiple times. If blank, will search all regions.")
 	a.RootCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "f", "", "Path to output file. If blank, will output to STDOUT")
 	a.RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "signal", "Output format (signal, json, yaml). Default value is signal")
+	a.RootCmd.PersistentFlags().StringVar(&a.RootFlags.HTTPProxy, "http-proxy", "", "HTTP/HTTPS proxy URL (e.g., http://proxy.example.com:8080)")
+	a.RootCmd.PersistentFlags().StringVar(&a.RootFlags.SOCKSProxy, "socks-proxy", "", "SOCKS proxy URL (e.g., socks5://proxy.example.com:1080)")
 
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/palantir/witchcraft-go-logging v1.61.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/net v0.43.0
 	k8s.io/api v0.33.4
 	k8s.io/apimachinery v0.33.4
 	k8s.io/client-go v0.33.4
@@ -63,7 +64,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,9 @@
 package config
 
 type RootFlags struct {
-	Quiet   bool
-	Verbose bool
-	Regions []string
+	Quiet      bool
+	Verbose    bool
+	Regions    []string
+	HTTPProxy  string
+	SOCKSProxy string
 }

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"golang.org/x/net/proxy"
+)
+
+type proxyContextKey struct{}
+
+// ProxyConfig captures global proxy settings for AWS SDK HTTP traffic.
+type ProxyConfig struct {
+	HTTPProxy  string
+	SOCKSProxy string
+}
+
+// SetProxyConfig stores proxy settings on the command context for paths that
+// create their own AWS config later in execution.
+func SetProxyConfig(ctx context.Context, proxyConfig ProxyConfig) context.Context {
+	return context.WithValue(ctx, proxyContextKey{}, proxyConfig)
+}
+
+// ProxyConfigFromContext returns proxy settings from context, if present.
+func ProxyConfigFromContext(ctx context.Context) ProxyConfig {
+	if proxyConfig, ok := ctx.Value(proxyContextKey{}).(ProxyConfig); ok {
+		return proxyConfig
+	}
+	return ProxyConfig{}
+}
+
+// AWSLoadOptionsForProxy returns AWS SDK config load options for proxy settings.
+func AWSLoadOptionsForProxy(proxyConfig ProxyConfig) ([]awsconfig.LoadOptionsFunc, error) {
+	client, err := HTTPClientForProxy(proxyConfig)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, nil
+	}
+	return []awsconfig.LoadOptionsFunc{awsconfig.WithHTTPClient(client)}, nil
+}
+
+// AWSLoadOptionsFromContext returns AWS SDK config load options from context.
+func AWSLoadOptionsFromContext(ctx context.Context) ([]awsconfig.LoadOptionsFunc, error) {
+	return AWSLoadOptionsForProxy(ProxyConfigFromContext(ctx))
+}
+
+// HTTPClientForProxy creates an HTTP client configured for HTTP(S) or SOCKS5 proxies.
+// If both proxy types are set, SOCKS5 takes precedence.
+func HTTPClientForProxy(proxyConfig ProxyConfig) (*http.Client, error) {
+	if proxyConfig.HTTPProxy == "" && proxyConfig.SOCKSProxy == "" {
+		return nil, nil
+	}
+
+	transport := defaultProxyTransport()
+	if proxyConfig.SOCKSProxy != "" {
+		if err := configureSOCKSProxy(transport, proxyConfig.SOCKSProxy); err != nil {
+			return nil, err
+		}
+		return &http.Client{Transport: transport}, nil
+	}
+
+	if err := configureHTTPProxy(transport, proxyConfig.HTTPProxy); err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
+func defaultProxyTransport() *http.Transport {
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return defaultTransport.Clone()
+	}
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+}
+
+func configureHTTPProxy(transport *http.Transport, rawProxyURL string) error {
+	proxyURL, err := url.Parse(rawProxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid HTTP proxy URL: %w", err)
+	}
+	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
+		return fmt.Errorf("invalid HTTP proxy scheme %q: expected http or https", proxyURL.Scheme)
+	}
+	if proxyURL.Host == "" {
+		return fmt.Errorf("invalid HTTP proxy URL: missing host")
+	}
+
+	transport.Proxy = http.ProxyURL(proxyURL)
+	return nil
+}
+
+func configureSOCKSProxy(transport *http.Transport, rawProxyURL string) error {
+	proxyURL, err := url.Parse(rawProxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid SOCKS proxy URL: %w", err)
+	}
+	if proxyURL.Scheme != "socks5" && proxyURL.Scheme != "socks5h" {
+		return fmt.Errorf("invalid SOCKS proxy scheme %q: expected socks5 or socks5h", proxyURL.Scheme)
+	}
+	if proxyURL.Host == "" {
+		return fmt.Errorf("invalid SOCKS proxy URL: missing host")
+	}
+
+	dialer, err := proxy.FromURL(proxyURL, proxy.Direct)
+	if err != nil {
+		return fmt.Errorf("failed to create SOCKS proxy dialer: %w", err)
+	}
+	contextDialer, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return fmt.Errorf("SOCKS proxy dialer does not support context-aware dialing")
+	}
+
+	transport.Proxy = noHTTPProxy
+	transport.DialContext = contextDialer.DialContext
+	return nil
+}
+
+func noHTTPProxy(*http.Request) (*url.URL, error) {
+	return nil, nil
+}

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -2,13 +2,11 @@ package config
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
-	"time"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"golang.org/x/net/proxy"
 )
@@ -20,6 +18,8 @@ type ProxyConfig struct {
 	HTTPProxy  string
 	SOCKSProxy string
 }
+
+type AWSLoadOption = func(*awsconfig.LoadOptions) error
 
 // SetProxyConfig stores proxy settings on the command context for paths that
 // create their own AWS config later in execution.
@@ -36,7 +36,7 @@ func ProxyConfigFromContext(ctx context.Context) ProxyConfig {
 }
 
 // AWSLoadOptionsForProxy returns AWS SDK config load options for proxy settings.
-func AWSLoadOptionsForProxy(proxyConfig ProxyConfig) ([]awsconfig.LoadOptionsFunc, error) {
+func AWSLoadOptionsForProxy(proxyConfig ProxyConfig) ([]AWSLoadOption, error) {
 	client, err := HTTPClientForProxy(proxyConfig)
 	if err != nil {
 		return nil, err
@@ -44,94 +44,79 @@ func AWSLoadOptionsForProxy(proxyConfig ProxyConfig) ([]awsconfig.LoadOptionsFun
 	if client == nil {
 		return nil, nil
 	}
-	return []awsconfig.LoadOptionsFunc{awsconfig.WithHTTPClient(client)}, nil
+	return []AWSLoadOption{awsconfig.WithHTTPClient(client)}, nil
 }
 
 // AWSLoadOptionsFromContext returns AWS SDK config load options from context.
-func AWSLoadOptionsFromContext(ctx context.Context) ([]awsconfig.LoadOptionsFunc, error) {
+func AWSLoadOptionsFromContext(ctx context.Context) ([]AWSLoadOption, error) {
 	return AWSLoadOptionsForProxy(ProxyConfigFromContext(ctx))
 }
 
-// HTTPClientForProxy creates an HTTP client configured for HTTP(S) or SOCKS5 proxies.
+// HTTPClientForProxy creates an AWS buildable HTTP client configured for HTTP(S) or SOCKS5 proxies.
 // If both proxy types are set, SOCKS5 takes precedence.
-func HTTPClientForProxy(proxyConfig ProxyConfig) (*http.Client, error) {
+func HTTPClientForProxy(proxyConfig ProxyConfig) (*awshttp.BuildableClient, error) {
 	if proxyConfig.HTTPProxy == "" && proxyConfig.SOCKSProxy == "" {
 		return nil, nil
 	}
 
-	transport := defaultProxyTransport()
+	client := awshttp.NewBuildableClient()
 	if proxyConfig.SOCKSProxy != "" {
-		if err := configureSOCKSProxy(transport, proxyConfig.SOCKSProxy); err != nil {
+		transportOption, err := socksProxyTransportOption(proxyConfig.SOCKSProxy)
+		if err != nil {
 			return nil, err
 		}
-		return &http.Client{Transport: transport}, nil
+		return client.WithTransportOptions(transportOption), nil
 	}
 
-	if err := configureHTTPProxy(transport, proxyConfig.HTTPProxy); err != nil {
+	transportOption, err := httpProxyTransportOption(proxyConfig.HTTPProxy)
+	if err != nil {
 		return nil, err
 	}
-	return &http.Client{Transport: transport}, nil
+	return client.WithTransportOptions(transportOption), nil
 }
 
-func defaultProxyTransport() *http.Transport {
-	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
-		return defaultTransport.Clone()
-	}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
-	}
-}
-
-func configureHTTPProxy(transport *http.Transport, rawProxyURL string) error {
+func httpProxyTransportOption(rawProxyURL string) (func(*http.Transport), error) {
 	proxyURL, err := url.Parse(rawProxyURL)
 	if err != nil {
-		return fmt.Errorf("invalid HTTP proxy URL: %w", err)
+		return nil, fmt.Errorf("invalid HTTP proxy URL: %w", err)
 	}
 	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
-		return fmt.Errorf("invalid HTTP proxy scheme %q: expected http or https", proxyURL.Scheme)
+		return nil, fmt.Errorf("invalid HTTP proxy scheme %q: expected http or https", proxyURL.Scheme)
 	}
 	if proxyURL.Host == "" {
-		return fmt.Errorf("invalid HTTP proxy URL: missing host")
+		return nil, fmt.Errorf("invalid HTTP proxy URL: missing host")
 	}
 
-	transport.Proxy = http.ProxyURL(proxyURL)
-	return nil
+	return func(transport *http.Transport) {
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}, nil
 }
 
-func configureSOCKSProxy(transport *http.Transport, rawProxyURL string) error {
+func socksProxyTransportOption(rawProxyURL string) (func(*http.Transport), error) {
 	proxyURL, err := url.Parse(rawProxyURL)
 	if err != nil {
-		return fmt.Errorf("invalid SOCKS proxy URL: %w", err)
+		return nil, fmt.Errorf("invalid SOCKS proxy URL: %w", err)
 	}
 	if proxyURL.Scheme != "socks5" && proxyURL.Scheme != "socks5h" {
-		return fmt.Errorf("invalid SOCKS proxy scheme %q: expected socks5 or socks5h", proxyURL.Scheme)
+		return nil, fmt.Errorf("invalid SOCKS proxy scheme %q: expected socks5 or socks5h", proxyURL.Scheme)
 	}
 	if proxyURL.Host == "" {
-		return fmt.Errorf("invalid SOCKS proxy URL: missing host")
+		return nil, fmt.Errorf("invalid SOCKS proxy URL: missing host")
 	}
 
 	dialer, err := proxy.FromURL(proxyURL, proxy.Direct)
 	if err != nil {
-		return fmt.Errorf("failed to create SOCKS proxy dialer: %w", err)
+		return nil, fmt.Errorf("failed to create SOCKS proxy dialer: %w", err)
 	}
 	contextDialer, ok := dialer.(proxy.ContextDialer)
 	if !ok {
-		return fmt.Errorf("SOCKS proxy dialer does not support context-aware dialing")
+		return nil, fmt.Errorf("SOCKS proxy dialer does not support context-aware dialing")
 	}
 
-	transport.Proxy = noHTTPProxy
-	transport.DialContext = contextDialer.DialContext
-	return nil
+	return func(transport *http.Transport) {
+		transport.Proxy = noHTTPProxy
+		transport.DialContext = contextDialer.DialContext
+	}, nil
 }
 
 func noHTTPProxy(*http.Request) (*url.URL, error) {

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -44,7 +45,15 @@ func AWSLoadOptionsForProxy(proxyConfig ProxyConfig) ([]AWSLoadOption, error) {
 	if client == nil {
 		return nil, nil
 	}
-	return []AWSLoadOption{awsconfig.WithHTTPClient(client)}, nil
+	loadOptions := []AWSLoadOption{awsconfig.WithHTTPClient(client)}
+	if proxyConfig.SOCKSProxy != "" {
+		transportOption, err := socksProxyTransportOption(proxyConfig.SOCKSProxy)
+		if err != nil {
+			return nil, err
+		}
+		loadOptions = append(loadOptions, awsconfig.WithServiceOptions(socksProxyServiceOption(transportOption)))
+	}
+	return loadOptions, nil
 }
 
 // AWSLoadOptionsFromContext returns AWS SDK config load options from context.
@@ -121,4 +130,30 @@ func socksProxyTransportOption(rawProxyURL string) (func(*http.Transport), error
 
 func noHTTPProxy(*http.Request) (*url.URL, error) {
 	return nil, nil
+}
+
+func socksProxyServiceOption(transportOption func(*http.Transport)) func(string, any) {
+	return func(_ string, options any) {
+		optionsValue := reflect.ValueOf(options)
+		if optionsValue.Kind() != reflect.Ptr || optionsValue.IsNil() {
+			return
+		}
+
+		optionsElement := optionsValue.Elem()
+		if optionsElement.Kind() != reflect.Struct {
+			return
+		}
+
+		httpClientField := optionsElement.FieldByName("HTTPClient")
+		if !httpClientField.IsValid() || !httpClientField.CanSet() || httpClientField.IsNil() {
+			return
+		}
+
+		buildableClient, ok := httpClientField.Interface().(*awshttp.BuildableClient)
+		if !ok {
+			return
+		}
+
+		httpClientField.Set(reflect.ValueOf(buildableClient.WithTransportOptions(transportOption)))
+	}
 }

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -1,11 +1,26 @@
 package config
 
 import (
+	"bufio"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
+	"math/big"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 )
 
 func TestHTTPClientForProxyReturnsNilWithoutProxy(t *testing.T) {
@@ -24,7 +39,7 @@ func TestHTTPClientForProxyConfiguresHTTPProxy(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	transport := client.Transport.(*http.Transport)
+	transport := client.GetTransport()
 	requestURL, err := url.Parse("https://sts.amazonaws.com")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
@@ -44,7 +59,7 @@ func TestHTTPClientForProxyConfiguresSOCKSProxy(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	transport := client.Transport.(*http.Transport)
+	transport := client.GetTransport()
 	if transport.DialContext == nil {
 		t.Fatal("expected SOCKS proxy to configure DialContext")
 	}
@@ -71,7 +86,7 @@ func TestHTTPClientForProxyPrefersSOCKSProxy(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	transport := client.Transport.(*http.Transport)
+	transport := client.GetTransport()
 	requestURL, err := url.Parse("https://sts.amazonaws.com")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
@@ -103,7 +118,7 @@ func TestSOCKSProxyDialContextHonorsCanceledContext(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	transport := client.Transport.(*http.Transport)
+	transport := client.GetTransport()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -123,4 +138,122 @@ func TestAWSLoadOptionsFromContext(t *testing.T) {
 	if len(loadOptions) != 1 {
 		t.Fatalf("expected one load option, got %d", len(loadOptions))
 	}
+}
+
+func TestProxyHTTPClientIsAWSBuildableClient(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{HTTPProxy: "http://127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, ok := any(client).(*awshttp.BuildableClient); !ok {
+		t.Fatalf("expected proxy client to be an AWS buildable client, got %T", client)
+	}
+}
+
+func TestAWSLoadOptionsWithProxySupportsCustomCABundle(t *testing.T) {
+	caBundlePath := writeTestCABundle(t)
+	t.Setenv("AWS_CA_BUNDLE", caBundlePath)
+
+	loadOptions, err := AWSLoadOptionsForProxy(ProxyConfig{HTTPProxy: "http://127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	loadOptions = append(loadOptions,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), loadOptions...)
+	if err != nil {
+		t.Fatalf("expected AWS config load with proxy and custom CA bundle to succeed, got %v", err)
+	}
+	if _, ok := cfg.HTTPClient.(*awshttp.BuildableClient); !ok {
+		t.Fatalf("expected custom CA bundle to preserve buildable client, got %T", cfg.HTTPClient)
+	}
+}
+
+func TestProxyHTTPClientPreservesAWSRedirectPolicy(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{HTTPProxy: "http://127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	client = client.WithTransportOptions(func(tr *http.Transport) {
+		tr.Proxy = nil
+		tr.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+			clientConn, serverConn := net.Pipe()
+			go func() {
+				defer serverConn.Close()
+
+				req, err := http.ReadRequest(bufio.NewReader(serverConn))
+				if err == nil {
+					_ = req.Body.Close()
+				}
+				_, _ = serverConn.Write([]byte("HTTP/1.1 302 Found\r\nLocation: http://redirected.example/\r\nContent-Length: 0\r\n\r\n"))
+			}()
+			return clientConn, nil
+		}
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://aws.example/", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected request to succeed, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected AWS redirect policy not to follow 302, got %d", resp.StatusCode)
+	}
+}
+
+func writeTestCABundle(t *testing.T) string {
+	t.Helper()
+
+	certDER := createSelfSignedCertificate(t)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if certPEM == nil {
+		t.Fatal("failed to encode certificate PEM")
+	}
+
+	if _, err := x509.ParseCertificate(certDER); err != nil {
+		t.Fatalf("test certificate is invalid: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "ca-bundle.pem")
+	if err := os.WriteFile(path, certPEM, 0600); err != nil {
+		t.Fatalf("failed to write CA bundle: %v", err)
+	}
+	return path
+}
+
+func createSelfSignedCertificate(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "methodaws proxy test CA",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to generate test certificate: %v", err)
+	}
+	return certDER
 }

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestHTTPClientForProxyReturnsNilWithoutProxy(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client != nil {
+		t.Fatal("expected no HTTP client when no proxy is configured")
+	}
+}
+
+func TestHTTPClientForProxyConfiguresHTTPProxy(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{HTTPProxy: "http://user:pass@127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	transport := client.Transport.(*http.Transport)
+	requestURL, err := url.Parse("https://sts.amazonaws.com")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+	if err != nil {
+		t.Fatalf("expected proxy lookup to succeed: %v", err)
+	}
+	if proxyURL.String() != "http://user:pass@127.0.0.1:8080" {
+		t.Fatalf("expected configured HTTP proxy, got %s", proxyURL.String())
+	}
+}
+
+func TestHTTPClientForProxyConfiguresSOCKSProxy(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{SOCKSProxy: "socks5://127.0.0.1:1080"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	transport := client.Transport.(*http.Transport)
+	if transport.DialContext == nil {
+		t.Fatal("expected SOCKS proxy to configure DialContext")
+	}
+
+	requestURL, err := url.Parse("https://sts.amazonaws.com")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+	if err != nil {
+		t.Fatalf("expected proxy lookup to succeed: %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("expected SOCKS proxy to disable HTTP proxy lookup, got %s", proxyURL.String())
+	}
+}
+
+func TestHTTPClientForProxyPrefersSOCKSProxy(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{
+		HTTPProxy:  "http://127.0.0.1:8080",
+		SOCKSProxy: "socks5://127.0.0.1:1080",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	transport := client.Transport.(*http.Transport)
+	requestURL, err := url.Parse("https://sts.amazonaws.com")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	proxyURL, err := transport.Proxy(&http.Request{URL: requestURL})
+	if err != nil {
+		t.Fatalf("expected proxy lookup to succeed: %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("expected SOCKS proxy to take precedence, got HTTP proxy %s", proxyURL.String())
+	}
+}
+
+func TestHTTPClientForProxyRejectsInvalidSchemes(t *testing.T) {
+	_, err := HTTPClientForProxy(ProxyConfig{HTTPProxy: "socks5://127.0.0.1:1080"})
+	if err == nil {
+		t.Fatal("expected invalid HTTP proxy scheme to fail")
+	}
+
+	_, err = HTTPClientForProxy(ProxyConfig{SOCKSProxy: "http://127.0.0.1:8080"})
+	if err == nil {
+		t.Fatal("expected invalid SOCKS proxy scheme to fail")
+	}
+}
+
+func TestSOCKSProxyDialContextHonorsCanceledContext(t *testing.T) {
+	client, err := HTTPClientForProxy(ProxyConfig{SOCKSProxy: "socks5://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	transport := client.Transport.(*http.Transport)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = transport.DialContext(ctx, "tcp", "sts.amazonaws.com:443")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+}
+
+func TestAWSLoadOptionsFromContext(t *testing.T) {
+	ctx := SetProxyConfig(context.Background(), ProxyConfig{HTTPProxy: "http://127.0.0.1:8080"})
+
+	loadOptions, err := AWSLoadOptionsFromContext(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(loadOptions) != 1 {
+		t.Fatalf("expected one load option, got %d", len(loadOptions))
+	}
+}

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,18 @@ func TestAWSLoadOptionsFromContext(t *testing.T) {
 	}
 }
 
+func TestAWSLoadOptionsFromContextIncludesSOCKSServiceOption(t *testing.T) {
+	ctx := SetProxyConfig(context.Background(), ProxyConfig{SOCKSProxy: "socks5://127.0.0.1:1"})
+
+	loadOptions, err := AWSLoadOptionsFromContext(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(loadOptions) != 2 {
+		t.Fatalf("expected HTTP client and service option load options, got %d", len(loadOptions))
+	}
+}
+
 func TestProxyHTTPClientIsAWSBuildableClient(t *testing.T) {
 	client, err := HTTPClientForProxy(ProxyConfig{HTTPProxy: "http://127.0.0.1:8080"})
 	if err != nil {
@@ -212,6 +225,46 @@ func TestProxyHTTPClientPreservesAWSRedirectPolicy(t *testing.T) {
 
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("expected AWS redirect policy not to follow 302, got %d", resp.StatusCode)
+	}
+}
+
+func TestSOCKSProxyServiceOptionRestoresDialContextAfterDefaults(t *testing.T) {
+	const socksProxyURL = "socks5://127.0.0.1:1"
+
+	client, err := HTTPClientForProxy(ProxyConfig{SOCKSProxy: socksProxyURL})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	client = client.WithDialerOptions(func(dialer *net.Dialer) {
+		dialer.Timeout = 50 * time.Millisecond
+	})
+
+	transportOption, err := socksProxyTransportOption(socksProxyURL)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	options := struct {
+		HTTPClient aws.HTTPClient
+	}{
+		HTTPClient: client,
+	}
+	socksProxyServiceOption(transportOption)("test", &options)
+
+	buildableClient, ok := options.HTTPClient.(*awshttp.BuildableClient)
+	if !ok {
+		t.Fatalf("expected buildable client, got %T", options.HTTPClient)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err = buildableClient.GetTransport().DialContext(ctx, "tcp", "example.invalid:80")
+	if err == nil {
+		t.Fatal("expected dial through closed SOCKS proxy port to fail")
+	}
+	if !strings.Contains(err.Error(), "127.0.0.1:1") {
+		t.Fatalf("expected dial to target SOCKS proxy endpoint, got %v", err)
 	}
 }
 

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -184,7 +184,9 @@ func TestProxyHTTPClientPreservesAWSRedirectPolicy(t *testing.T) {
 		tr.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			clientConn, serverConn := net.Pipe()
 			go func() {
-				defer serverConn.Close()
+				defer func() {
+					_ = serverConn.Close()
+				}()
 
 				req, err := http.ReadRequest(bufio.NewReader(serverConn))
 				if err == nil {
@@ -204,7 +206,9 @@ func TestProxyHTTPClientPreservesAWSRedirectPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected request to succeed, got %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("expected AWS redirect policy not to follow 302, got %d", resp.StatusCode)

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -32,7 +32,7 @@ func bucketExists(ctx context.Context, region string, bucketName string) (bool, 
 			svc1log.Stacktrace(err))
 		return false, fmt.Errorf("error configuring proxy: %v", err)
 	}
-	loadOptions = append([]awsconfig.LoadOptionsFunc{
+	loadOptions = append([]methodconfig.AWSLoadOption{
 		awsconfig.WithRegion(region),
 		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
 	}, loadOptions...)
@@ -300,7 +300,7 @@ func externalS3Region(ctx context.Context, bucketURL string, bucketName string, 
 		errors = append(errors, fmt.Sprintf("error configuring proxy: %v", err))
 		return nil, errors
 	}
-	loadOptions = append([]awsconfig.LoadOptionsFunc{
+	loadOptions = append([]methodconfig.AWSLoadOption{
 		awsconfig.WithRegion(region),
 		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
 	}, loadOptions...)

--- a/internal/s3/external/external.go
+++ b/internal/s3/external/external.go
@@ -8,11 +8,12 @@ import (
 
 	// Generated
 	s3fern "github.com/Method-Security/methodaws/generated/go/s3"
+	methodconfig "github.com/Method-Security/methodaws/internal/config"
 	"github.com/Method-Security/methodaws/utils"
 
 	// External
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -23,9 +24,20 @@ func bucketExists(ctx context.Context, region string, bucketName string) (bool, 
 	log := svc1log.FromContext(ctx)
 
 	// Create a custom AWS config with anonymous credentials
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	loadOptions, err := methodconfig.AWSLoadOptionsFromContext(ctx)
+	if err != nil {
+		log.Error("Failed to configure proxy for bucket existence check",
+			svc1log.SafeParam("bucketName", bucketName),
+			svc1log.SafeParam("region", region),
+			svc1log.Stacktrace(err))
+		return false, fmt.Errorf("error configuring proxy: %v", err)
+	}
+	loadOptions = append([]awsconfig.LoadOptionsFunc{
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	}, loadOptions...)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		loadOptions...,
 	)
 	if err != nil {
 		log.Error("Failed to load AWS config for bucket existence check",
@@ -280,9 +292,20 @@ func externalS3Region(ctx context.Context, bucketURL string, bucketName string, 
 	errors := []string{}
 
 	// Create a custom AWS config with anonymous credentials
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	loadOptions, err := methodconfig.AWSLoadOptionsFromContext(ctx)
+	if err != nil {
+		log.Error("Failed to configure proxy for external enumeration",
+			svc1log.SafeParam("region", region),
+			svc1log.Stacktrace(err))
+		errors = append(errors, fmt.Sprintf("error configuring proxy: %v", err))
+		return nil, errors
+	}
+	loadOptions = append([]awsconfig.LoadOptionsFunc{
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	}, loadOptions...)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		loadOptions...,
 	)
 	if err != nil {
 		log.Error("Failed to load AWS config for external enumeration",

--- a/internal/s3/external/seed.go
+++ b/internal/s3/external/seed.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	s3fern "github.com/Method-Security/methodaws/generated/go/s3"
-
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 

--- a/vendor/golang.org/x/net/internal/socks/client.go
+++ b/vendor/golang.org/x/net/internal/socks/client.go
@@ -1,0 +1,168 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package socks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+var (
+	noDeadline   = time.Time{}
+	aLongTimeAgo = time.Unix(1, 0)
+)
+
+func (d *Dialer) connect(ctx context.Context, c net.Conn, address string) (_ net.Addr, ctxErr error) {
+	host, port, err := splitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+		c.SetDeadline(deadline)
+		defer c.SetDeadline(noDeadline)
+	}
+	if ctx != context.Background() {
+		errCh := make(chan error, 1)
+		done := make(chan struct{})
+		defer func() {
+			close(done)
+			if ctxErr == nil {
+				ctxErr = <-errCh
+			}
+		}()
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.SetDeadline(aLongTimeAgo)
+				errCh <- ctx.Err()
+			case <-done:
+				errCh <- nil
+			}
+		}()
+	}
+
+	b := make([]byte, 0, 6+len(host)) // the size here is just an estimate
+	b = append(b, Version5)
+	if len(d.AuthMethods) == 0 || d.Authenticate == nil {
+		b = append(b, 1, byte(AuthMethodNotRequired))
+	} else {
+		ams := d.AuthMethods
+		if len(ams) > 255 {
+			return nil, errors.New("too many authentication methods")
+		}
+		b = append(b, byte(len(ams)))
+		for _, am := range ams {
+			b = append(b, byte(am))
+		}
+	}
+	if _, ctxErr = c.Write(b); ctxErr != nil {
+		return
+	}
+
+	if _, ctxErr = io.ReadFull(c, b[:2]); ctxErr != nil {
+		return
+	}
+	if b[0] != Version5 {
+		return nil, errors.New("unexpected protocol version " + strconv.Itoa(int(b[0])))
+	}
+	am := AuthMethod(b[1])
+	if am == AuthMethodNoAcceptableMethods {
+		return nil, errors.New("no acceptable authentication methods")
+	}
+	if d.Authenticate != nil {
+		if ctxErr = d.Authenticate(ctx, c, am); ctxErr != nil {
+			return
+		}
+	}
+
+	b = b[:0]
+	b = append(b, Version5, byte(d.cmd), 0)
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			b = append(b, AddrTypeIPv4)
+			b = append(b, ip4...)
+		} else if ip6 := ip.To16(); ip6 != nil {
+			b = append(b, AddrTypeIPv6)
+			b = append(b, ip6...)
+		} else {
+			return nil, errors.New("unknown address type")
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("FQDN too long")
+		}
+		b = append(b, AddrTypeFQDN)
+		b = append(b, byte(len(host)))
+		b = append(b, host...)
+	}
+	b = append(b, byte(port>>8), byte(port))
+	if _, ctxErr = c.Write(b); ctxErr != nil {
+		return
+	}
+
+	if _, ctxErr = io.ReadFull(c, b[:4]); ctxErr != nil {
+		return
+	}
+	if b[0] != Version5 {
+		return nil, errors.New("unexpected protocol version " + strconv.Itoa(int(b[0])))
+	}
+	if cmdErr := Reply(b[1]); cmdErr != StatusSucceeded {
+		return nil, errors.New("unknown error " + cmdErr.String())
+	}
+	if b[2] != 0 {
+		return nil, errors.New("non-zero reserved field")
+	}
+	l := 2
+	var a Addr
+	switch b[3] {
+	case AddrTypeIPv4:
+		l += net.IPv4len
+		a.IP = make(net.IP, net.IPv4len)
+	case AddrTypeIPv6:
+		l += net.IPv6len
+		a.IP = make(net.IP, net.IPv6len)
+	case AddrTypeFQDN:
+		if _, err := io.ReadFull(c, b[:1]); err != nil {
+			return nil, err
+		}
+		l += int(b[0])
+	default:
+		return nil, errors.New("unknown address type " + strconv.Itoa(int(b[3])))
+	}
+	if cap(b) < l {
+		b = make([]byte, l)
+	} else {
+		b = b[:l]
+	}
+	if _, ctxErr = io.ReadFull(c, b); ctxErr != nil {
+		return
+	}
+	if a.IP != nil {
+		copy(a.IP, b)
+	} else {
+		a.Name = string(b[:len(b)-2])
+	}
+	a.Port = int(b[len(b)-2])<<8 | int(b[len(b)-1])
+	return &a, nil
+}
+
+func splitHostPort(address string) (string, int, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", 0, err
+	}
+	portnum, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+	if 1 > portnum || portnum > 0xffff {
+		return "", 0, errors.New("port number out of range " + port)
+	}
+	return host, portnum, nil
+}

--- a/vendor/golang.org/x/net/internal/socks/socks.go
+++ b/vendor/golang.org/x/net/internal/socks/socks.go
@@ -1,0 +1,317 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package socks provides a SOCKS version 5 client implementation.
+//
+// SOCKS protocol version 5 is defined in RFC 1928.
+// Username/Password authentication for SOCKS version 5 is defined in
+// RFC 1929.
+package socks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+)
+
+// A Command represents a SOCKS command.
+type Command int
+
+func (cmd Command) String() string {
+	switch cmd {
+	case CmdConnect:
+		return "socks connect"
+	case cmdBind:
+		return "socks bind"
+	default:
+		return "socks " + strconv.Itoa(int(cmd))
+	}
+}
+
+// An AuthMethod represents a SOCKS authentication method.
+type AuthMethod int
+
+// A Reply represents a SOCKS command reply code.
+type Reply int
+
+func (code Reply) String() string {
+	switch code {
+	case StatusSucceeded:
+		return "succeeded"
+	case 0x01:
+		return "general SOCKS server failure"
+	case 0x02:
+		return "connection not allowed by ruleset"
+	case 0x03:
+		return "network unreachable"
+	case 0x04:
+		return "host unreachable"
+	case 0x05:
+		return "connection refused"
+	case 0x06:
+		return "TTL expired"
+	case 0x07:
+		return "command not supported"
+	case 0x08:
+		return "address type not supported"
+	default:
+		return "unknown code: " + strconv.Itoa(int(code))
+	}
+}
+
+// Wire protocol constants.
+const (
+	Version5 = 0x05
+
+	AddrTypeIPv4 = 0x01
+	AddrTypeFQDN = 0x03
+	AddrTypeIPv6 = 0x04
+
+	CmdConnect Command = 0x01 // establishes an active-open forward proxy connection
+	cmdBind    Command = 0x02 // establishes a passive-open forward proxy connection
+
+	AuthMethodNotRequired         AuthMethod = 0x00 // no authentication required
+	AuthMethodUsernamePassword    AuthMethod = 0x02 // use username/password
+	AuthMethodNoAcceptableMethods AuthMethod = 0xff // no acceptable authentication methods
+
+	StatusSucceeded Reply = 0x00
+)
+
+// An Addr represents a SOCKS-specific address.
+// Either Name or IP is used exclusively.
+type Addr struct {
+	Name string // fully-qualified domain name
+	IP   net.IP
+	Port int
+}
+
+func (a *Addr) Network() string { return "socks" }
+
+func (a *Addr) String() string {
+	if a == nil {
+		return "<nil>"
+	}
+	port := strconv.Itoa(a.Port)
+	if a.IP == nil {
+		return net.JoinHostPort(a.Name, port)
+	}
+	return net.JoinHostPort(a.IP.String(), port)
+}
+
+// A Conn represents a forward proxy connection.
+type Conn struct {
+	net.Conn
+
+	boundAddr net.Addr
+}
+
+// BoundAddr returns the address assigned by the proxy server for
+// connecting to the command target address from the proxy server.
+func (c *Conn) BoundAddr() net.Addr {
+	if c == nil {
+		return nil
+	}
+	return c.boundAddr
+}
+
+// A Dialer holds SOCKS-specific options.
+type Dialer struct {
+	cmd          Command // either CmdConnect or cmdBind
+	proxyNetwork string  // network between a proxy server and a client
+	proxyAddress string  // proxy server address
+
+	// ProxyDial specifies the optional dial function for
+	// establishing the transport connection.
+	ProxyDial func(context.Context, string, string) (net.Conn, error)
+
+	// AuthMethods specifies the list of request authentication
+	// methods.
+	// If empty, SOCKS client requests only AuthMethodNotRequired.
+	AuthMethods []AuthMethod
+
+	// Authenticate specifies the optional authentication
+	// function. It must be non-nil when AuthMethods is not empty.
+	// It must return an error when the authentication is failed.
+	Authenticate func(context.Context, io.ReadWriter, AuthMethod) error
+}
+
+// DialContext connects to the provided address on the provided
+// network.
+//
+// The returned error value may be a net.OpError. When the Op field of
+// net.OpError contains "socks", the Source field contains a proxy
+// server address and the Addr field contains a command target
+// address.
+//
+// See func Dial of the net package of standard library for a
+// description of the network and address parameters.
+func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if ctx == nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: errors.New("nil context")}
+	}
+	var err error
+	var c net.Conn
+	if d.ProxyDial != nil {
+		c, err = d.ProxyDial(ctx, d.proxyNetwork, d.proxyAddress)
+	} else {
+		var dd net.Dialer
+		c, err = dd.DialContext(ctx, d.proxyNetwork, d.proxyAddress)
+	}
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	a, err := d.connect(ctx, c, address)
+	if err != nil {
+		c.Close()
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	return &Conn{Conn: c, boundAddr: a}, nil
+}
+
+// DialWithConn initiates a connection from SOCKS server to the target
+// network and address using the connection c that is already
+// connected to the SOCKS server.
+//
+// It returns the connection's local address assigned by the SOCKS
+// server.
+func (d *Dialer) DialWithConn(ctx context.Context, c net.Conn, network, address string) (net.Addr, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if ctx == nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: errors.New("nil context")}
+	}
+	a, err := d.connect(ctx, c, address)
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	return a, nil
+}
+
+// Dial connects to the provided address on the provided network.
+//
+// Unlike DialContext, it returns a raw transport connection instead
+// of a forward proxy connection.
+//
+// Deprecated: Use DialContext or DialWithConn instead.
+func (d *Dialer) Dial(network, address string) (net.Conn, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	var err error
+	var c net.Conn
+	if d.ProxyDial != nil {
+		c, err = d.ProxyDial(context.Background(), d.proxyNetwork, d.proxyAddress)
+	} else {
+		c, err = net.Dial(d.proxyNetwork, d.proxyAddress)
+	}
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if _, err := d.DialWithConn(context.Background(), c, network, address); err != nil {
+		c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (d *Dialer) validateTarget(network, address string) error {
+	switch network {
+	case "tcp", "tcp6", "tcp4":
+	default:
+		return errors.New("network not implemented")
+	}
+	switch d.cmd {
+	case CmdConnect, cmdBind:
+	default:
+		return errors.New("command not implemented")
+	}
+	return nil
+}
+
+func (d *Dialer) pathAddrs(address string) (proxy, dst net.Addr, err error) {
+	for i, s := range []string{d.proxyAddress, address} {
+		host, port, err := splitHostPort(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		a := &Addr{Port: port}
+		a.IP = net.ParseIP(host)
+		if a.IP == nil {
+			a.Name = host
+		}
+		if i == 0 {
+			proxy = a
+		} else {
+			dst = a
+		}
+	}
+	return
+}
+
+// NewDialer returns a new Dialer that dials through the provided
+// proxy server's network and address.
+func NewDialer(network, address string) *Dialer {
+	return &Dialer{proxyNetwork: network, proxyAddress: address, cmd: CmdConnect}
+}
+
+const (
+	authUsernamePasswordVersion = 0x01
+	authStatusSucceeded         = 0x00
+)
+
+// UsernamePassword are the credentials for the username/password
+// authentication method.
+type UsernamePassword struct {
+	Username string
+	Password string
+}
+
+// Authenticate authenticates a pair of username and password with the
+// proxy server.
+func (up *UsernamePassword) Authenticate(ctx context.Context, rw io.ReadWriter, auth AuthMethod) error {
+	switch auth {
+	case AuthMethodNotRequired:
+		return nil
+	case AuthMethodUsernamePassword:
+		if len(up.Username) == 0 || len(up.Username) > 255 || len(up.Password) > 255 {
+			return errors.New("invalid username/password")
+		}
+		b := []byte{authUsernamePasswordVersion}
+		b = append(b, byte(len(up.Username)))
+		b = append(b, up.Username...)
+		b = append(b, byte(len(up.Password)))
+		b = append(b, up.Password...)
+		// TODO(mikio): handle IO deadlines and cancelation if
+		// necessary
+		if _, err := rw.Write(b); err != nil {
+			return err
+		}
+		if _, err := io.ReadFull(rw, b[:2]); err != nil {
+			return err
+		}
+		if b[0] != authUsernamePasswordVersion {
+			return errors.New("invalid username/password version")
+		}
+		if b[1] != authStatusSucceeded {
+			return errors.New("username/password authentication failed")
+		}
+		return nil
+	}
+	return errors.New("unsupported authentication method " + strconv.Itoa(int(auth)))
+}

--- a/vendor/golang.org/x/net/proxy/dial.go
+++ b/vendor/golang.org/x/net/proxy/dial.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"net"
+)
+
+// A ContextDialer dials using a context.
+type ContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Dial works like DialContext on net.Dialer but using a dialer returned by FromEnvironment.
+//
+// The passed ctx is only used for returning the Conn, not the lifetime of the Conn.
+//
+// Custom dialers (registered via RegisterDialerType) that do not implement ContextDialer
+// can leak a goroutine for as long as it takes the underlying Dialer implementation to timeout.
+//
+// A Conn returned from a successful Dial after the context has been cancelled will be immediately closed.
+func Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	d := FromEnvironment()
+	if xd, ok := d.(ContextDialer); ok {
+		return xd.DialContext(ctx, network, address)
+	}
+	return dialContext(ctx, d, network, address)
+}
+
+// WARNING: this can leak a goroutine for as long as the underlying Dialer implementation takes to timeout
+// A Conn returned from a successful Dial after the context has been cancelled will be immediately closed.
+func dialContext(ctx context.Context, d Dialer, network, address string) (net.Conn, error) {
+	var (
+		conn net.Conn
+		done = make(chan struct{}, 1)
+		err  error
+	)
+	go func() {
+		conn, err = d.Dial(network, address)
+		close(done)
+		if conn != nil && ctx.Err() != nil {
+			conn.Close()
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	case <-done:
+	}
+	return conn, err
+}

--- a/vendor/golang.org/x/net/proxy/direct.go
+++ b/vendor/golang.org/x/net/proxy/direct.go
@@ -1,0 +1,31 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"net"
+)
+
+type direct struct{}
+
+// Direct implements Dialer by making network connections directly using net.Dial or net.DialContext.
+var Direct = direct{}
+
+var (
+	_ Dialer        = Direct
+	_ ContextDialer = Direct
+)
+
+// Dial directly invokes net.Dial with the supplied parameters.
+func (direct) Dial(network, addr string) (net.Conn, error) {
+	return net.Dial(network, addr)
+}
+
+// DialContext instantiates a net.Dialer and invokes its DialContext receiver with the supplied parameters.
+func (direct) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, network, addr)
+}

--- a/vendor/golang.org/x/net/proxy/per_host.go
+++ b/vendor/golang.org/x/net/proxy/per_host.go
@@ -1,0 +1,153 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// A PerHost directs connections to a default Dialer unless the host name
+// requested matches one of a number of exceptions.
+type PerHost struct {
+	def, bypass Dialer
+
+	bypassNetworks []*net.IPNet
+	bypassIPs      []net.IP
+	bypassZones    []string
+	bypassHosts    []string
+}
+
+// NewPerHost returns a PerHost Dialer that directs connections to either
+// defaultDialer or bypass, depending on whether the connection matches one of
+// the configured rules.
+func NewPerHost(defaultDialer, bypass Dialer) *PerHost {
+	return &PerHost{
+		def:    defaultDialer,
+		bypass: bypass,
+	}
+}
+
+// Dial connects to the address addr on the given network through either
+// defaultDialer or bypass.
+func (p *PerHost) Dial(network, addr string) (c net.Conn, err error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.dialerForRequest(host).Dial(network, addr)
+}
+
+// DialContext connects to the address addr on the given network through either
+// defaultDialer or bypass.
+func (p *PerHost) DialContext(ctx context.Context, network, addr string) (c net.Conn, err error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	d := p.dialerForRequest(host)
+	if x, ok := d.(ContextDialer); ok {
+		return x.DialContext(ctx, network, addr)
+	}
+	return dialContext(ctx, d, network, addr)
+}
+
+func (p *PerHost) dialerForRequest(host string) Dialer {
+	if nip, err := netip.ParseAddr(host); err == nil {
+		ip := net.IP(nip.AsSlice())
+		for _, net := range p.bypassNetworks {
+			if net.Contains(ip) {
+				return p.bypass
+			}
+		}
+		for _, bypassIP := range p.bypassIPs {
+			if bypassIP.Equal(ip) {
+				return p.bypass
+			}
+		}
+		return p.def
+	}
+
+	for _, zone := range p.bypassZones {
+		if strings.HasSuffix(host, zone) {
+			return p.bypass
+		}
+		if host == zone[1:] {
+			// For a zone ".example.com", we match "example.com"
+			// too.
+			return p.bypass
+		}
+	}
+	for _, bypassHost := range p.bypassHosts {
+		if bypassHost == host {
+			return p.bypass
+		}
+	}
+	return p.def
+}
+
+// AddFromString parses a string that contains comma-separated values
+// specifying hosts that should use the bypass proxy. Each value is either an
+// IP address, a CIDR range, a zone (*.example.com) or a host name
+// (localhost). A best effort is made to parse the string and errors are
+// ignored.
+func (p *PerHost) AddFromString(s string) {
+	hosts := strings.Split(s, ",")
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if len(host) == 0 {
+			continue
+		}
+		if strings.Contains(host, "/") {
+			// We assume that it's a CIDR address like 127.0.0.0/8
+			if _, net, err := net.ParseCIDR(host); err == nil {
+				p.AddNetwork(net)
+			}
+			continue
+		}
+		if nip, err := netip.ParseAddr(host); err == nil {
+			p.AddIP(net.IP(nip.AsSlice()))
+			continue
+		}
+		if strings.HasPrefix(host, "*.") {
+			p.AddZone(host[1:])
+			continue
+		}
+		p.AddHost(host)
+	}
+}
+
+// AddIP specifies an IP address that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match an IP.
+func (p *PerHost) AddIP(ip net.IP) {
+	p.bypassIPs = append(p.bypassIPs, ip)
+}
+
+// AddNetwork specifies an IP range that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match.
+func (p *PerHost) AddNetwork(net *net.IPNet) {
+	p.bypassNetworks = append(p.bypassNetworks, net)
+}
+
+// AddZone specifies a DNS suffix that will use the bypass proxy. A zone of
+// "example.com" matches "example.com" and all of its subdomains.
+func (p *PerHost) AddZone(zone string) {
+	zone = strings.TrimSuffix(zone, ".")
+	if !strings.HasPrefix(zone, ".") {
+		zone = "." + zone
+	}
+	p.bypassZones = append(p.bypassZones, zone)
+}
+
+// AddHost specifies a host name that will use the bypass proxy.
+func (p *PerHost) AddHost(host string) {
+	host = strings.TrimSuffix(host, ".")
+	p.bypassHosts = append(p.bypassHosts, host)
+}

--- a/vendor/golang.org/x/net/proxy/proxy.go
+++ b/vendor/golang.org/x/net/proxy/proxy.go
@@ -1,0 +1,149 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package proxy provides support for a variety of protocols to proxy network
+// data.
+package proxy // import "golang.org/x/net/proxy"
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"sync"
+)
+
+// A Dialer is a means to establish a connection.
+// Custom dialers should also implement ContextDialer.
+type Dialer interface {
+	// Dial connects to the given address via the proxy.
+	Dial(network, addr string) (c net.Conn, err error)
+}
+
+// Auth contains authentication parameters that specific Dialers may require.
+type Auth struct {
+	User, Password string
+}
+
+// FromEnvironment returns the dialer specified by the proxy-related
+// variables in the environment and makes underlying connections
+// directly.
+func FromEnvironment() Dialer {
+	return FromEnvironmentUsing(Direct)
+}
+
+// FromEnvironmentUsing returns the dialer specify by the proxy-related
+// variables in the environment and makes underlying connections
+// using the provided forwarding Dialer (for instance, a *net.Dialer
+// with desired configuration).
+func FromEnvironmentUsing(forward Dialer) Dialer {
+	allProxy := allProxyEnv.Get()
+	if len(allProxy) == 0 {
+		return forward
+	}
+
+	proxyURL, err := url.Parse(allProxy)
+	if err != nil {
+		return forward
+	}
+	proxy, err := FromURL(proxyURL, forward)
+	if err != nil {
+		return forward
+	}
+
+	noProxy := noProxyEnv.Get()
+	if len(noProxy) == 0 {
+		return proxy
+	}
+
+	perHost := NewPerHost(proxy, forward)
+	perHost.AddFromString(noProxy)
+	return perHost
+}
+
+// proxySchemes is a map from URL schemes to a function that creates a Dialer
+// from a URL with such a scheme.
+var proxySchemes map[string]func(*url.URL, Dialer) (Dialer, error)
+
+// RegisterDialerType takes a URL scheme and a function to generate Dialers from
+// a URL with that scheme and a forwarding Dialer. Registered schemes are used
+// by FromURL.
+func RegisterDialerType(scheme string, f func(*url.URL, Dialer) (Dialer, error)) {
+	if proxySchemes == nil {
+		proxySchemes = make(map[string]func(*url.URL, Dialer) (Dialer, error))
+	}
+	proxySchemes[scheme] = f
+}
+
+// FromURL returns a Dialer given a URL specification and an underlying
+// Dialer for it to make network requests.
+func FromURL(u *url.URL, forward Dialer) (Dialer, error) {
+	var auth *Auth
+	if u.User != nil {
+		auth = new(Auth)
+		auth.User = u.User.Username()
+		if p, ok := u.User.Password(); ok {
+			auth.Password = p
+		}
+	}
+
+	switch u.Scheme {
+	case "socks5", "socks5h":
+		addr := u.Hostname()
+		port := u.Port()
+		if port == "" {
+			port = "1080"
+		}
+		return SOCKS5("tcp", net.JoinHostPort(addr, port), auth, forward)
+	}
+
+	// If the scheme doesn't match any of the built-in schemes, see if it
+	// was registered by another package.
+	if proxySchemes != nil {
+		if f, ok := proxySchemes[u.Scheme]; ok {
+			return f(u, forward)
+		}
+	}
+
+	return nil, errors.New("proxy: unknown scheme: " + u.Scheme)
+}
+
+var (
+	allProxyEnv = &envOnce{
+		names: []string{"ALL_PROXY", "all_proxy"},
+	}
+	noProxyEnv = &envOnce{
+		names: []string{"NO_PROXY", "no_proxy"},
+	}
+)
+
+// envOnce looks up an environment variable (optionally by multiple
+// names) once. It mitigates expensive lookups on some platforms
+// (e.g. Windows).
+// (Borrowed from net/http/transport.go)
+type envOnce struct {
+	names []string
+	once  sync.Once
+	val   string
+}
+
+func (e *envOnce) Get() string {
+	e.once.Do(e.init)
+	return e.val
+}
+
+func (e *envOnce) init() {
+	for _, n := range e.names {
+		e.val = os.Getenv(n)
+		if e.val != "" {
+			return
+		}
+	}
+}
+
+// reset is used by tests
+func (e *envOnce) reset() {
+	e.once = sync.Once{}
+	e.val = ""
+}

--- a/vendor/golang.org/x/net/proxy/socks5.go
+++ b/vendor/golang.org/x/net/proxy/socks5.go
@@ -1,0 +1,42 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/net/internal/socks"
+)
+
+// SOCKS5 returns a Dialer that makes SOCKSv5 connections to the given
+// address with an optional username and password.
+// See RFC 1928 and RFC 1929.
+func SOCKS5(network, address string, auth *Auth, forward Dialer) (Dialer, error) {
+	d := socks.NewDialer(network, address)
+	if forward != nil {
+		if f, ok := forward.(ContextDialer); ok {
+			d.ProxyDial = func(ctx context.Context, network string, address string) (net.Conn, error) {
+				return f.DialContext(ctx, network, address)
+			}
+		} else {
+			d.ProxyDial = func(ctx context.Context, network string, address string) (net.Conn, error) {
+				return dialContext(ctx, forward, network, address)
+			}
+		}
+	}
+	if auth != nil {
+		up := socks.UsernamePassword{
+			Username: auth.User,
+			Password: auth.Password,
+		}
+		d.AuthMethods = []socks.AuthMethod{
+			socks.AuthMethodNotRequired,
+			socks.AuthMethodUsernamePassword,
+		}
+		d.Authenticate = up.Authenticate
+	}
+	return d, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -396,6 +396,8 @@ golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/httpcommon
+golang.org/x/net/internal/socks
+golang.org/x/net/proxy
 # golang.org/x/oauth2 v0.30.0
 ## explicit; go 1.23.0
 golang.org/x/oauth2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Opt-in but centralizes how AWS HTTP traffic is routed; SOCKS support relies on reflection to patch SDK service clients, which could be fragile across SDK upgrades.
> 
> **Overview**
> Adds global **`--http-proxy`** and **`--socks-proxy`** flags so AWS API calls can run through corporate or tunnel proxies. Flag values are stored on the command **context** and turned into AWS SDK v2 load options (custom **buildable HTTP client**); **SOCKS5** wins when both are set.
> 
> **`internal/config/proxy.go`** implements URL validation, HTTP `ProxyURL` wiring, SOCKS dialing via **`golang.org/x/net/proxy`**, and an extra **service option** so per-service SDK clients keep the SOCKS transport. Root **`setupCommonConfig`** applies these options when loading the main AWS config; **external S3** paths that build their own anonymous configs now merge the same proxy options from context.
> 
> Includes broad **`proxy_test`** coverage (schemes, precedence, context cancellation, CA bundle compatibility, redirect behavior). **`golang.org/x/net`** is a direct dependency with vendored **proxy/socks** packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e3a21ea9cc067e51c262baf22ccc1b933aa9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->