### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "4.68.4"
+  "version": "5.65.3"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.34.5
+        version: 1.46.4
         config:
           importPath: github.com/Method-Security/methodaws/generated/go
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only tooling version bumps with no application or generated code changes in the PR; the main follow-up risk is a potentially large diff the next time Go types are regenerated.
> 
> **Overview**
> Bumps the **Fern platform** pin in `fern/fern.config.json` from **4.68.4** to **5.65.3** and upgrades the **local** `fernapi/fern-go-sdk` generator in `fern/generators.yml` from **1.34.5** to **1.46.4**.
> 
> **Pydantic** generator versions and other generator groups are unchanged. There is no regenerated `generated/go` output in this diff—only the versions used when running `fern generate --group local` (and the matching Fern CLI) are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278122e9cb905276460206f82b674c43a09e2d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->