### PR TITLE
upgrade to go 1.26.4

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 jobs:
   # Build ARM64 using native GitHub ARM runner but inside Docker for Alpine compatibility

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled methodaws binary
-FROM golang:1.26.3-alpine3.22 AS base
+FROM golang:1.26.4-alpine3.22 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="methodaws"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Method-Security/methodaws
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Method-Security/pkg v0.0.6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level toolchain-only change with no application logic or dependency updates in the diff.
> 
> **Overview**
> Bumps the project’s Go toolchain from **1.26.3** to **1.26.4** so local builds, CI, and containerized releases all use the same patch release.
> 
> `go.mod` declares the new minimum Go version. **Verify** workflow `setup-go` and the reusable build workflow’s `GO_VERSION` env are updated accordingly. `Dockerfile.builder` now bases on `golang:1.26.4-alpine3.22` for Alpine/Linux GoReleaser builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05640b3096503b4d99bb2895661fff868192c7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->