### PR TITLE
Fix release version injection and Linux snapshot builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -60,7 +60,7 @@ jobs:
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm armbuilder \
-            goreleaser build --single-target --clean --snapshot --timeout 60m \
+            goreleaser build --single-target --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
@@ -113,7 +113,7 @@ jobs:
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm amdbuilder \
-            goreleaser build --single-target --clean --snapshot --timeout 60m \
+            goreleaser build --single-target --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -12,7 +12,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X github.com/method-security/methodaws/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,7 +27,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X github.com/method-security/methodaws/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:
@@ -41,7 +41,7 @@ builds:
     binary: methodaws
     ldflags:
       - -s -w
-      - -X github.com/method-security/methodaws/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:
@@ -55,7 +55,7 @@ builds:
     binary: methodaws
     ldflags:
       - -s -w
-      - -X github.com/method-security/methodaws/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -12,7 +12,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X main.version={{.Version}}
+      - -X main.Version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,7 +27,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X main.version={{.Version}}
+      - -X main.Version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:
@@ -41,7 +41,7 @@ builds:
     binary: methodaws
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
+      - -X main.Version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:
@@ -55,7 +55,7 @@ builds:
     binary: methodaws
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
+      - -X main.Version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,206 @@
+# methodaws Project Context
+
+## Overview
+
+methodaws is a comprehensive AWS security scanning and enumeration tool that provides security teams with data-rich insights into AWS cloud environments. It follows the CLI Development Conventions for attack stage organization and implements discover, enumerate, and pentest capabilities.
+
+## Architecture
+
+The tool follows the standard CLI Development Conventions with clear separation by attack stages:
+
+### Attack Stages
+
+1. **Discover Stage** (`internal/*/`)
+   - AWS service discovery and basic reconnaissance
+   - Credential validation and account enumeration
+   - Service availability and region mapping
+
+2. **Enumerate Stage** (`internal/*/`)
+   - Deep inspection of AWS resources
+   - Configuration extraction and analysis
+   - Permission and policy enumeration
+
+3. **Pentest Stage** (`internal/*/`)
+   - Active testing of AWS security configurations
+   - Privilege escalation testing
+   - Security control bypass attempts
+
+### Core Components
+
+1. **AWS Service Modules** (`internal/*/`)
+   - EC2, S3, IAM, RDS, EKS, Lambda, Route53
+   - VPC, Security Groups, Load Balancers
+   - API Gateway, CloudFront, WAF, Elastic Beanstalk
+
+2. **Authentication** (`internal/sts/`)
+   - AWS credential management
+   - Role assumption and cross-account access
+   - Session token handling
+
+3. **Common Utilities** (`internal/common/`)
+   - AWS region handling
+   - Shared AWS client configurations
+   - Error handling patterns
+
+### CLI Structure (`cmd/`)
+- `root.go` - Main CLI setup with Cobra
+- `<service>.go` - Individual service command implementations
+- Following naming convention: `<stage><Service>Cmd` pattern
+
+### Generated Code (`generated/go/`)
+- Fern-generated Go types and clients
+- AWS service definitions and data structures
+- Type-safe AWS API interfaces
+
+## Project Structure
+
+- **Language**: Go
+- **Module**: github.com/Method-Security/methodaws
+- **CLI Framework**: Cobra
+- **Type Generation**: Fern
+- **AWS SDK**: AWS SDK for Go v2
+- **Testing**: Standard Go testing + AWS integration tests
+
+## Key AWS Services Supported
+
+- **Compute**: EC2, EKS, Lambda, Elastic Beanstalk
+- **Storage**: S3
+- **Networking**: VPC, Security Groups, Load Balancers, Route53
+- **Security**: IAM, WAF, CloudFront
+- **Database**: RDS
+- **API**: API Gateway
+
+## Development Patterns
+
+### CLI Command Structure
+Follow CLI Development Conventions:
+- Use `<stage>Cmd` in camelCase for top-level commands
+- Use `<stage><Component>Cmd` for subcommands
+- Implement Run functions with action verbs (e.g., `RunEc2Discovery`)
+
+### Flag Naming
+- Use kebab-case for CLI flags: `--scan-type`
+- Use camelCase when extracting flags: `scanType, err := cmd.Flags().GetString("scan-type")`
+- Always check errors when extracting flags
+- Use `.GetStringSlice` for slice inputs with plural flag names
+
+### AWS Integration
+- Use AWS SDK v2 for all AWS interactions
+- Implement proper credential chain handling
+- Support cross-account role assumption
+- Handle AWS region selection properly
+- Implement rate limiting and error retry logic
+
+### Error Handling
+```go
+if err != nil {
+    a.OutputSignal.AddError(err)
+    return
+}
+```
+
+### Fern Type Requirements
+- **MANDATORY**: Every CLI command with output must have a corresponding Fern report structure
+- **Three-Part Structure Pattern**: All commands must define:
+  ```yaml
+  # 1. Config type for input parameters
+  <Stage><Component>Config:
+    properties:
+      # AWS-specific configuration parameters
+      region: optional<AwsRegion>
+      profile: optional<string>
+      roleArn: optional<string>
+  
+  # 2. Result type for output data
+  <Stage><Component>Result:
+    properties:
+      # AWS service-specific result data
+      instances: optional<list<Ec2Instance>>
+      buckets: optional<list<S3Bucket>>
+  
+  # 3. Report type wrapping config, result, and errors
+  <Stage><Component>Report:
+    properties:
+      config: <Stage><Component>Config
+      result: <Stage><Component>Result
+      errors: optional<list<string>>
+  ```
+- **AWS Example Implementation**:
+  ```yaml
+  Ec2EnumerateConfig:
+    properties:
+      region: optional<AwsRegion>
+      instanceIds: optional<list<string>>
+  
+  Ec2EnumerateResult:
+    properties:
+      instances: optional<list<Ec2Instance>>
+  
+  Ec2EnumerateReport:
+    properties:
+      config: Ec2EnumerateConfig
+      result: Ec2EnumerateResult
+      errors: optional<list<string>>
+  ```
+- **AWS-Specific Types**: Include AWS-specific enums and objects:
+  ```yaml
+  AwsRegion:
+    enum: [US_EAST_1, US_WEST_2, EU_WEST_1, ...]
+  InstanceType:
+    enum: [T2_MICRO, T3_SMALL, M5_LARGE, ...]
+  ```
+- **Type Organization**: Follow the CLI Development Conventions type ordering:
+  1. ENUMs (e.g., `AwsRegion`, `InstanceState`)
+  2. Common Objects (e.g., `AwsCredential`, `Ec2Instance`)
+  3. Config Types (e.g., `Ec2EnumerateConfig`)
+  4. Result Types (e.g., `Ec2EnumerateResult`)
+  5. Report Types (e.g., `Ec2EnumerateReport`)
+
+### Output Structure
+```go
+a.OutputSignal.Content = report
+```
+
+## Important Notes
+
+- **AWS Credentials**: Requires proper AWS credentials configured (environment variables, profile, or IAM role)
+- **Permissions**: Different commands require different AWS permissions
+- **Rate Limits**: Be mindful of AWS API rate limits
+- **Cross-Account**: Support for cross-account role assumption
+- **Regions**: Handle multi-region scanning appropriately
+
+## Development Commands
+
+```bash
+# MANDATORY: Run after completing TODOs to ensure code can be merged
+./godelw verify
+
+# Build the binary
+./godelw build
+```
+
+## Development Workflow
+
+1. Follow CLI Development Conventions for new commands
+2. Use Fern definitions for type safety
+3. Implement proper AWS error handling
+4. Test with multiple AWS accounts and regions
+5. Follow existing patterns for consistency
+6. **CRITICAL**: Always run `./godelw verify` after TODO completion before merging
+
+## File Structure Conventions
+
+- `/cmd/` - CLI command implementations
+- `/internal/<service>/` - AWS service implementations
+- `/fern/definition/` - Fern API definitions
+- `/generated/go/` - Generated Go code
+- `/docs/` - Documentation
+
+## Development Practices
+
+- Follow CLI Development Conventions exactly
+- Use proper AWS SDK patterns
+- Implement comprehensive error handling
+- Support multiple AWS regions
+- Handle AWS rate limiting gracefully
+- Always end files with a single newline


### PR DESCRIPTION
Two release-path defects, both invisible to PR CI because `test-build.yml` runs `goreleaser build` and never `release` — so neither shows up until a tag is pushed. Same fix as [networkscan#342](https://github.com/method-security/networkscan/pull/342); every Method Go CLI shares the first one.

---

## 1. The version ldflag has never applied

The builds set `-X github.com/method-security/methodaws/main.version={{.Version}}`. That symbol path matches neither the module path — `github.com/Method-Security/methodaws`, capitalised — nor the `main` package, which sits at the module root and so has no `/main` segment. The Go linker silently ignores `-X` for a symbol it can't resolve, so the injection is a no-op.

This is not theoretical. Running the **shipped release binaries**:

```
$ ./osintscan version     # from osintscan v0.0.101 macOS-ARM64
none
$ ./networkscan version   # from networkscan v0.1.2 macOS-ARM64
none
```

Both should print their tag. Confirmed the mechanism directly by building a sibling repo both ways:

```
$ go build -ldflags "-X github.com/method-security/networkscan/main.version=TESTVER" .
$ ./networkscan version
none
$ go build -ldflags "-X main.version=TESTVER2" .
$ ./networkscan version
TESTVER2
```

Switched to `-X main.version={{.Version}}`, the conventional form for a root `main` package.

## 2. Both Linux builds are forced into snapshot mode on releases

`prepare-linux-arm64` and `prepare-linux-amd64` hardcoded `--clean --snapshot` *in addition to* passing `${{ inputs.goreleaser_options }}`:

```yaml
goreleaser build --single-target --clean --snapshot --timeout 60m \
  -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
```

On a tagged release `release.yml` supplies `goreleaser_options: "--clean"`, so both Linux binaries are built in snapshot mode while the `prepare` matrix (macOS/Windows) — which passes inputs through unmodified — uses the real tag. Even once (1) is fixed, Linux would report a *different* version than every other artifact in the same release.

Now passes inputs through the same way, keeping `--timeout 60m`. The PR path is unaffected: `test-build.yml` already supplies `--clean --snapshot` explicitly, so snapshot behaviour there is unchanged.

---

## Verification

The ldflag mechanism is proven by the commands above. The `--snapshot` change is config-only and can't be exercised without pushing a tag — the argument is the flag precedence described above, and PR builds keep their existing `--clean --snapshot`.

Worth confirming on the next release that `version` returns the tag rather than `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and build-metadata changes only; no application logic or security paths modified. Residual risk is verifying the next tagged release prints the expected version on Linux artifacts.
> 
> **Overview**
> Fixes **release artifacts reporting `none` for version** and **Linux binaries diverging from other platforms on tagged releases**.
> 
> GoReleaser ldflags now use `-X main.Version={{.Version}}` instead of a non-resolving `github.com/method-security/methodaws/main.version` path (and wrong symbol casing), so the linker actually injects the release tag into `main.Version` for all build targets in `goreleaser-build.yml`.
> 
> The reusable workflow’s **Linux ARM64/AMD64** Docker `goreleaser build` steps no longer hardcode `--clean --snapshot`; they only keep `--single-target --timeout 60m` and forward `${{ inputs.goreleaser_options }}`, aligning Linux with macOS/Windows on real releases while PR snapshot builds still get `--clean --snapshot` from the caller.
> 
> Also adds **`CLAUDE.md`** as project/agent context documentation (no runtime behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e4c1a9e10cf9937ff08c1fdc75a8ed46748067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->