### PR TITLE
Have CI install the latest Go 1.26.x patch instead of a pinned patch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26"
 
 jobs:
   # Build ARM64 using native GitHub ARM runner but inside Docker for Alpine compatibility
@@ -173,6 +173,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # ratchet:goreleaser/goreleaser-action@v7
@@ -250,6 +251,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Download Artifacts

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -46,9 +46,14 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
 
-      # Build ARM64 builder image natively (no QEMU needed)
+      # Build ARM64 builder image natively (no QEMU needed).
+      # --pull ensures the floating golang:${GO_VERSION}-alpine* tag is refreshed
+      # so Linux picks up the same latest 1.26.x patch as setup-go check-latest.
       - name: Build ARM64 Builder Image
-        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
+        run: >
+          docker buildx build . --platform linux/arm64 --load --pull
+          --build-arg GO_VERSION=${{ env.GO_VERSION }}
+          --tag armbuilder -f Dockerfile.builder
 
       # Build inside the Alpine container to ensure library compatibility
       - name: Build ARM64 Binary in Alpine Container
@@ -99,9 +104,14 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
 
-      # Build AMD64 builder image natively (no QEMU needed)
+      # Build AMD64 builder image natively (no QEMU needed).
+      # --pull ensures the floating golang:${GO_VERSION}-alpine* tag is refreshed
+      # so Linux picks up the same latest 1.26.x patch as setup-go check-latest.
       - name: Build AMD64 Builder Image
-        run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
+        run: >
+          docker buildx build . --platform linux/amd64 --load --pull
+          --build-arg GO_VERSION=${{ env.GO_VERSION }}
+          --tag amdbuilder -f Dockerfile.builder
 
       # Build inside the Alpine container to ensure library compatibility
       - name: Build AMD64 Binary in Alpine Container

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26"
+          check-latest: true
 
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,8 @@
 # Dockerfile used for the compilation of the statically compiled methodaws binary
-FROM golang:1.26.5-alpine3.23 AS base
+# GO_VERSION should be a minor (e.g. 1.26) so the floating golang:<minor>-alpine*
+# tag tracks the latest patch, matching setup-go check-latest in CI.
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine3.23 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="methodaws"
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Use a fuzzy `go-version` (`1.26`) with `check-latest: true` in `reusable-build.yml` and `verify.yml` so CI always installs the newest available 1.26 patch release instead of a version pinned to a specific patch.
- `go.mod` is left unchanged, keeping its exact minimum version pin.

## Test plan
- [ ] CI (verify/reusable-build workflows) runs green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI and Docker build tooling change; no application or runtime dependency logic is modified.
> 
> **Overview**
> CI no longer pins Go to **1.26.5**; workflows use minor version **`1.26`** with **`check-latest: true`** on `setup-go` so macOS/Windows and aggregate build jobs pick up the newest 1.26 patch available on the runner.
> 
> Linux ARM64/AMD64 builds stay in **`Dockerfile.builder`**, which now takes a **`GO_VERSION`** build arg (default **`1.26`**) instead of a hard-coded `golang:1.26.5-alpine` image. **`docker buildx`** passes that arg and adds **`--pull`** so the floating `golang:<minor>-alpine*` tag refreshes to the latest patch, aligned with `setup-go`.
> 
> **`go.mod`** is unchanged and still declares the exact minimum **`go 1.26.5`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f01dd2dba1dbafb9eaba137d18aaf10b125bcc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->